### PR TITLE
유저 리스트 뷰 생성

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/feed/FeedDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/feed/FeedDataSource.java
@@ -12,5 +12,5 @@ public interface FeedDataSource {
     Single<List<Feed>> getAllFeed();
 
     // 피드 검색 결과 요청
-    Single<List<Feed>> searchFeed(String searchKey);
+    Single<List<Feed>> searchAllFeed(String searchKey);
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/feed/FeedRemoteDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/feed/FeedRemoteDataSource.java
@@ -36,7 +36,7 @@ public class FeedRemoteDataSource implements FeedDataSource {
     }
 
     @Override
-    public Single<List<Feed>> searchFeed(String searchKey) {
+    public Single<List<Feed>> searchAllFeed(String searchKey) {
 
         // TODO. 임시 코드 삭제
         List<Feed> feedList = new ArrayList<>();

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/feed/FeedRepository.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/feed/FeedRepository.java
@@ -70,8 +70,8 @@ public class FeedRepository implements FeedDataSource {
     }
 
     @Override
-    public Single<List<Feed>> searchFeed(String searchKey) {
+    public Single<List<Feed>> searchAllFeed(String searchKey) {
 
-        return remoteDataSource.searchFeed(searchKey);
+        return remoteDataSource.searchAllFeed(searchKey);
     }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserDataSource.java
@@ -10,8 +10,8 @@ import io.reactivex.Single;
 public interface UserDataSource {
 
     // 유저 검색 리스트 요청
-    Single<List<User>> getUserList(String searchKey);
+    Single<List<User>> searchAllUser(String searchKey);
 
     // 유저 프로필 정보 요청
-    Single<UserInfo> getUserDetail(String userId);
+    Single<UserInfo> getUserInfo(String userId);
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRemoteDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRemoteDataSource.java
@@ -27,7 +27,7 @@ public class UserRemoteDataSource implements UserDataSource {
     }
 
     @Override
-    public Single<List<User>> getUserList(String searchKey) {
+    public Single<List<User>> searchAllUser(String searchKey) {
 
         // TODO. 임시 데이터
         List<User> userList = new ArrayList<>();
@@ -41,7 +41,7 @@ public class UserRemoteDataSource implements UserDataSource {
     }
 
     @Override
-    public Single<UserInfo> getUserDetail(String userId) {
+    public Single<UserInfo> getUserInfo(String userId) {
 
         // TODO. 임시 데이터
         UserInfo user = new UserInfo();

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRepository.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRepository.java
@@ -29,14 +29,14 @@ public class UserRepository implements UserDataSource {
     }
 
     @Override
-    public Single<List<User>> getUserList(String searchKey) {
+    public Single<List<User>> searchAllUser(String searchKey) {
 
-        return remoteDataSource.getUserList(searchKey);
+        return remoteDataSource.searchAllUser(searchKey);
     }
 
     @Override
-    public Single<UserInfo> getUserDetail(String userId) {
+    public Single<UserInfo> getUserInfo(String userId) {
 
-        return remoteDataSource.getUserDetail(userId);
+        return remoteDataSource.getUserInfo(userId);
     }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/view/feedList/FeedListFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/feedList/FeedListFragment.java
@@ -1,7 +1,6 @@
 package com.boostcamp.dreampicker.view.feedList;
 
 import android.annotation.SuppressLint;
-import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -27,7 +26,7 @@ public class FeedListFragment extends BaseFragment<FragmentFeedListBinding> {
 
     public FeedListFragment(){}
 
-    public static FeedListFragment getInstance() {
+    public static FeedListFragment newInstance() {
 
         return new FeedListFragment();
     }

--- a/app/src/main/java/com/boostcamp/dreampicker/view/feedList/FeedListFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/feedList/FeedListFragment.java
@@ -69,7 +69,7 @@ public class FeedListFragment extends BaseFragment<FragmentFeedListBinding> {
 
     @SuppressLint("CheckResult")
     private void loadData() {
-        repository.searchFeed("")
+        repository.searchAllFeed("")
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this.adapter::addItems,
                         error -> Log.d("", error.getLocalizedMessage()));

--- a/app/src/main/java/com/boostcamp/dreampicker/view/main/FrameActivity.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/main/FrameActivity.java
@@ -9,6 +9,7 @@ import com.boostcamp.dreampicker.databinding.ActivityFrameBinding;
 import com.boostcamp.dreampicker.view.BaseActivity;
 import com.boostcamp.dreampicker.view.feedDetail.FeedDetailFragment;
 import com.boostcamp.dreampicker.view.profile.ProfileFragment;
+import com.boostcamp.dreampicker.view.userList.UserListFragment;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -18,13 +19,14 @@ public class FrameActivity extends BaseActivity<ActivityFrameBinding> {
     private static final String EXTRA_ENTITY_ID = "EXTRA_ENTITY_ID";
     public static final int FRAGMENT_FEED_DETAIL = 0;
     public static final int FRAGMENT_PROFILE = 1;
+    public static final int FRAGMENT_USER_LIST = 2;
 
     private int fragmentId;
     private String entityId;
 
     public static void startActivity(Context context,
-                                   int fragmentId,
-                                   String entityId){
+                                     int fragmentId,
+                                     String entityId){
 
         Intent intent = new Intent(context, FrameActivity.class);
         intent.putExtra(EXTRA_FRAGMENT_ID, fragmentId);
@@ -63,6 +65,9 @@ public class FrameActivity extends BaseActivity<ActivityFrameBinding> {
                 break;
             case FRAGMENT_PROFILE:
                 fragment = ProfileFragment.newInstance();
+                break;
+            case FRAGMENT_USER_LIST:
+                fragment = UserListFragment.newInstance();
                 break;
         }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/view/profile/ProfileFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/profile/ProfileFragment.java
@@ -11,6 +11,7 @@ import com.boostcamp.dreampicker.data.source.user.UserRepository;
 import com.boostcamp.dreampicker.databinding.FragmentProfileBinding;
 import com.boostcamp.dreampicker.view.BaseFragment;
 import com.boostcamp.dreampicker.view.feedList.FeedListFragment;
+import com.boostcamp.dreampicker.view.main.FrameActivity;
 import com.google.android.material.tabs.TabLayout;
 
 import androidx.annotation.NonNull;
@@ -63,6 +64,10 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
             TabLayout.Tab tab = binding.tabProfile.getTabAt(i);
             tab.setText(getResources().getStringArray(R.array.profile_tab_names)[i]);
         }
+
+        // TODO. 임시코드
+        binding.layoutFollower.container.setOnClickListener(this::startFrameActivity);
+        binding.layoutFollowing.container.setOnClickListener(this::startFrameActivity);
     }
 
     @SuppressLint("CheckResult")
@@ -71,6 +76,12 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(binding::setUser,
                         error -> Log.d("", error.getLocalizedMessage()));
+    }
+
+    /** 임시입니다.
+     * TODO. ViewModel 로 이동 */
+    private void startFrameActivity(View view){
+        FrameActivity.startActivity(getContext(), FrameActivity.FRAGMENT_USER_LIST, "");
     }
 
     class ProfilePagerAdapter extends FragmentPagerAdapter {

--- a/app/src/main/java/com/boostcamp/dreampicker/view/profile/ProfileFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/profile/ProfileFragment.java
@@ -79,8 +79,8 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
 
         public ProfilePagerAdapter(@NonNull FragmentManager fm) {
             super(fm);
-            fragments[0] = FeedListFragment.getInstance();
-            fragments[1] = FeedListFragment.getInstance();
+            fragments[0] = FeedListFragment.newInstance();
+            fragments[1] = FeedListFragment.newInstance();
         }
 
         @NonNull

--- a/app/src/main/java/com/boostcamp/dreampicker/view/profile/ProfileFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/profile/ProfileFragment.java
@@ -67,7 +67,7 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
 
     @SuppressLint("CheckResult")
     private void loadData() {
-        repository.getUserDetail("")
+        repository.getUserInfo("")
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(binding::setUser,
                         error -> Log.d("", error.getLocalizedMessage()));

--- a/app/src/main/java/com/boostcamp/dreampicker/view/search/SearchFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/search/SearchFragment.java
@@ -9,6 +9,7 @@ import com.boostcamp.dreampicker.data.source.feed.FeedRepository;
 import com.boostcamp.dreampicker.databinding.FragmentSearchBinding;
 import com.boostcamp.dreampicker.view.BaseFragment;
 import com.boostcamp.dreampicker.view.feedList.FeedListFragment;
+import com.boostcamp.dreampicker.view.userList.UserListFragment;
 import com.google.android.material.tabs.TabLayout;
 
 import androidx.annotation.NonNull;
@@ -74,8 +75,8 @@ public class SearchFragment extends BaseFragment<FragmentSearchBinding> {
 
         public SearchPagerAdapter(@NonNull FragmentManager fm) {
             super(fm);
-            fragments[0] = FeedListFragment.getInstance();
-            fragments[1] = FeedListFragment.getInstance();
+            fragments[0] = UserListFragment.newInstance();
+            fragments[1] = FeedListFragment.newInstance();
         }
 
         @NonNull

--- a/app/src/main/java/com/boostcamp/dreampicker/view/userList/UserListAdapter.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/userList/UserListAdapter.java
@@ -1,0 +1,40 @@
+package com.boostcamp.dreampicker.view.userList;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.databinding.ItemUserListBinding;
+import com.boostcamp.dreampicker.model.User;
+import com.boostcamp.dreampicker.view.adapter.BaseRecyclerViewAdapter;
+
+import androidx.annotation.NonNull;
+import androidx.databinding.DataBindingUtil;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class UserListAdapter extends BaseRecyclerViewAdapter<User, UserListAdapter.ViewHolder> {
+
+    @Override
+    protected void onBindView(ViewHolder holder, int position) {
+
+        holder.binding.setUser(itemList.get(position));
+    }
+
+    @NonNull
+    @Override
+    public RecyclerView.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_user_list, parent, false);
+        return new ViewHolder(view);
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder{
+
+        ItemUserListBinding binding;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            binding = DataBindingUtil.bind(itemView);
+        }
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/view/userList/UserListFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/view/userList/UserListFragment.java
@@ -1,0 +1,76 @@
+package com.boostcamp.dreampicker.view.userList;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+
+import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.data.source.user.UserRepository;
+import com.boostcamp.dreampicker.databinding.FragmentUserListBinding;
+import com.boostcamp.dreampicker.model.User;
+import com.boostcamp.dreampicker.view.BaseFragment;
+import com.boostcamp.dreampicker.view.main.FrameActivity;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+
+public class UserListFragment extends BaseFragment<FragmentUserListBinding> {
+
+    // TODO. ViewModel 로 이동
+    private UserRepository repository = UserRepository.getInstance();
+
+    private UserListAdapter adapter;
+
+    public UserListFragment() {}
+
+    public static UserListFragment newInstance(){
+
+        return new UserListFragment();
+    }
+
+    @Override
+    protected int getLayoutId() {
+        return R.layout.fragment_user_list;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        initView();
+
+        // TODO. ViewModel 로 이동
+        loadData();
+    }
+
+    private void initView() {
+
+        // 리사이클러뷰
+        adapter = new UserListAdapter();
+        adapter.setOnItemClickListener(position -> startFrameActivity(adapter.getItemList().get(position)));
+        binding.recyclerUserList.setAdapter(adapter);
+        binding.recyclerUserList.setLayoutManager(new LinearLayoutManager(getContext(), RecyclerView.VERTICAL, false));
+    }
+
+    @SuppressLint("CheckResult")
+    private void loadData() {
+        repository.searchAllUser("")
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(this.adapter::addItems,
+                        error -> Log.d("", error.getLocalizedMessage()));
+    }
+
+    private void startFrameActivity(User user) {
+        FrameActivity.startActivity(getContext(), FrameActivity.FRAGMENT_PROFILE, "");
+    }
+}

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -63,11 +63,13 @@
                                 layout="@layout/layout_profile_count"/>
 
                             <include
+                                android:id="@+id/layout_follower"
                                 bind:count="@{String.valueOf(50)}"
                                 bind:title="@{String.valueOf(@string/profile_follower_count)}"
                                 layout="@layout/layout_profile_count"/>
 
                             <include
+                                android:id="@+id/layout_following"
                                 bind:count="@{String.valueOf(250)}"
                                 bind:title="@{String.valueOf(@string/profile_following_count)}"
                                 layout="@layout/layout_profile_count"/>

--- a/app/src/main/res/layout/fragment_user_list.xml
+++ b/app/src/main/res/layout/fragment_user_list.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_user_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</layout>

--- a/app/src/main/res/layout/item_feed.xml
+++ b/app/src/main/res/layout/item_feed.xml
@@ -20,7 +20,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:cardCornerRadius="5dp"
-            app:cardElevation="4dp"
             app:cardUseCompatPadding="true">
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/item_user_list.xml
+++ b/app/src/main/res/layout/item_user_list.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="user"
+            type="com.boostcamp.dreampicker.model.User"/>
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="5dp"
+        app:cardElevation="4dp"
+        app:cardUseCompatPadding="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="@dimen/profile_image_size_median"
+                android:layout_height="@dimen/profile_image_size_median"
+                android:layout_margin="@dimen/space_median"
+                style="@style/ImageView"
+                android:src="@drawable/profile"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/text_large"
+                android:textColor="@color/colorBlack"
+                android:text="@{user.name}"/>
+
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/layout_profile_count.xml
+++ b/app/src/main/res/layout/layout_profile_count.xml
@@ -11,6 +11,7 @@
     </data>
 
     <LinearLayout
+        android:id="@+id/container"
         android:orientation="vertical"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,7 +26,8 @@
     <dimen name="text_sub_size">12sp</dimen>
 
     <!-- Profile Image Size -->
-    <dimen name="profile_image_size_median">40dp</dimen>
+    <dimen name="profile_image_size_small">40dp</dimen>
+    <dimen name="profile_image_size_median">60dp</dimen>
     <dimen name="profile_image_size_large">80dp</dimen>
 
     <!-- Feed Image Size -->


### PR DESCRIPTION
﻿### 개요
* 유저 목록 보여줄 뷰 생성 

* 사용되는 곳: 
 1. 검색 탭의 사용자검색
 2. 프로필의 팔로워, 팔로잉 목록

<hr>

### 체크리스트
- [x] UserRepository, DataSource 수정
- [x] UserListFragment, UserListAdapter 생성
- [x] FrameActivity 에 UserListFragment 추가 (프로필에서 팔로워목록 열기위함)

<hr>

### 스크린샷
<div>
<img src="https://user-images.githubusercontent.com/22764812/52033272-bcbef080-2567-11e9-884d-e8402d6f3bb0.png" width=160 height=300> 검색 
<img src="https://user-images.githubusercontent.com/22764812/52033297-d829fb80-2567-11e9-9de5-850dd943aaa4.png" width=160 height=300/> 팔로워,팔로잉 목록 
</div>

<hr>

- **툴바 공유하기 위한 뷰와 툴바 뷰모델이 필요해보입니다.**

<hr>

- resolved : #46 