### PR TITLE
파이어베이스 - 유저 정보검색

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserDataSource.java
@@ -1,10 +1,12 @@
 package com.boostcamp.dreampicker.data.source.user;
 
+import com.boostcamp.dreampicker.model.Feed;
 import com.boostcamp.dreampicker.model.User;
 import com.boostcamp.dreampicker.model.UserInfo;
 
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import io.reactivex.Single;
 
 public interface UserDataSource {
@@ -14,4 +16,6 @@ public interface UserDataSource {
 
     // 유저 프로필 정보 요청
     Single<UserInfo> getUserInfo(String userId);
+
+    Single<List<Feed>> searchAllFeed(String searchKey, @Nullable Boolean isEnded);
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRemoteDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRemoteDataSource.java
@@ -1,15 +1,18 @@
 package com.boostcamp.dreampicker.data.source.user;
 
 import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.model.Feed;
 import com.boostcamp.dreampicker.model.User;
 import com.boostcamp.dreampicker.model.UserInfo;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import io.reactivex.Single;
 
 public class UserRemoteDataSource implements UserDataSource {
+
 
     private static UserRemoteDataSource userRemoteDataSource = null;
 
@@ -32,12 +35,19 @@ public class UserRemoteDataSource implements UserDataSource {
         // TODO. 임시 데이터
         List<User> userList = new ArrayList<>();
         User user = new User("" ,"yeseul",R.drawable.profile);
+
         userList.add(user);
         userList.add(user);
         userList.add(user);
         userList.add(user);
 
         return Single.just(userList);
+
+    }
+
+    @Override
+    public Single<List<Feed>> searchAllFeed(String searchKey, @Nullable Boolean isEnded) {
+        return null;
     }
 
     @Override

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRemoteDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRemoteDataSource.java
@@ -1,9 +1,10 @@
 package com.boostcamp.dreampicker.data.source.user;
 
-import com.boostcamp.dreampicker.R;
 import com.boostcamp.dreampicker.model.Feed;
 import com.boostcamp.dreampicker.model.User;
 import com.boostcamp.dreampicker.model.UserInfo;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +14,7 @@ import io.reactivex.Single;
 
 public class UserRemoteDataSource implements UserDataSource {
 
+    private static final String COLLECTION_USER = "user";
 
     private static UserRemoteDataSource userRemoteDataSource = null;
 
@@ -32,22 +34,26 @@ public class UserRemoteDataSource implements UserDataSource {
     @Override
     public Single<List<User>> searchAllUser(String searchKey) {
 
-        // TODO. 임시 데이터
-        List<User> userList = new ArrayList<>();
-        User user = new User("" ,"yeseul",R.drawable.profile);
-
-        userList.add(user);
-        userList.add(user);
-        userList.add(user);
-        userList.add(user);
-
-        return Single.just(userList);
-
+        final List<User> users = new ArrayList<>();
+        return Single.create(emitter -> FirebaseFirestore.getInstance().collection(COLLECTION_USER)
+                // TODO : 검색로직 구현후 주석해제
+                //.whereEqualTo("name",searchKey)
+                .get()
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        for (QueryDocumentSnapshot document : task.getResult()) {
+                            users.add(document.toObject(User.class));
+                            emitter.onSuccess(users);
+                        }
+                    } else {
+                        emitter.onError(task.getException());
+                    }
+                }));
     }
 
     @Override
     public Single<List<Feed>> searchAllFeed(String searchKey, @Nullable Boolean isEnded) {
-        return null;
+       return null;
     }
 
     @Override

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRepository.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/user/UserRepository.java
@@ -1,10 +1,12 @@
 package com.boostcamp.dreampicker.data.source.user;
 
+import com.boostcamp.dreampicker.model.Feed;
 import com.boostcamp.dreampicker.model.User;
 import com.boostcamp.dreampicker.model.UserInfo;
 
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import io.reactivex.Single;
 
 public class UserRepository implements UserDataSource {
@@ -38,5 +40,10 @@ public class UserRepository implements UserDataSource {
     public Single<UserInfo> getUserInfo(String userId) {
 
         return remoteDataSource.getUserInfo(userId);
+    }
+
+    @Override
+    public Single<List<Feed>> searchAllFeed(String searchKey, @Nullable Boolean isEnded) {
+        return null;
     }
 }


### PR DESCRIPTION
﻿### 개요
- 검색 화면에서 유저 이름을 검색하면 파이어베이스에서 데이터 가져오기
- 검색 로직이 구현되면 주석을 해제하여 수정필요

<hr>

### 체크리스트
- [x] searchAllUser 인터페이스 생성
- [x] searchAllUser 이름으로 쿼리 구현

<hr>

- resolved : #63 