### PR TITLE
메인피드 - 태그 리스트로 표현

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/data/model/Image.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/model/Image.java
@@ -34,6 +34,13 @@ public class Image {
         this.tagList = tagList;
     }
 
+    // Test
+    public Image(String id, int image, List<String> tagList) {
+        this.id = id;
+        this.image = image;
+        this.tagList = tagList;
+    }
+
     public String getId() {
         return id;
     }

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/FeedMockDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/FeedMockDataSource.java
@@ -31,8 +31,8 @@ public class FeedMockDataSource implements FeedDataSource {
     @Override
     public Single<List<Feed>> getAllFeed() {
         List<Feed> feedList = new ArrayList<>();
-        Image image1 = new Image("image-0-up", R.drawable.image1, "카페");
-        Image image2 = new Image("image-0-down", R.drawable.image2, "술집");
+        Image image1 = new Image("image-0-up", R.drawable.image1, Arrays.asList("1번", "2번", "3번"));
+        Image image2 = new Image("image-0-down", R.drawable.image2, Arrays.asList("1213112312","2","3","4","5","6","7"));
         User user1 = new User("user-0", "박신혜", R.drawable.profile);
         Feed feed1 = new Feed(
                 "feed-0",
@@ -43,8 +43,8 @@ public class FeedMockDataSource implements FeedDataSource {
                 false
         );
 
-        Image image3 = new Image("image-1-up", R.drawable.jajang, "짜장면");
-        Image image4 = new Image("image-1-down", R.drawable.jambong, "짬뽕");
+        Image image3 = new Image("image-1-up", R.drawable.jajang, Arrays.asList("짬뽕","굿"));
+        Image image4 = new Image("image-1-down", R.drawable.jambong, Arrays.asList("이것도짬뽕ㅎㅎ", "ㅋㅋㅋ"));
         User user2 = new User("user-1", "공유", R.drawable.profile2);
 
         Feed feed2 = new Feed(

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedAdapter.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedAdapter.java
@@ -42,11 +42,11 @@ public class FeedAdapter extends ListAdapter<Feed, FeedViewHolder> {
 
         holder.getBinding().sbSelector.setOnTouchListener(voteTouchListener);
 
-        holder.getBinding().flFeedLeft.setOnDragListener(new VoteDragListener(
+        holder.getBinding().ivFeedImageLeft.setOnDragListener(new VoteDragListener(
                 () -> onVoteListener.onVote(
                         new VoteResult(getItem(holder.getAdapterPosition()), Constant.LEFT))));
 
-        holder.getBinding().flFeedRight.setOnDragListener(new VoteDragListener(
+        holder.getBinding().ivFeedImageRight.setOnDragListener(new VoteDragListener(
                 () -> onVoteListener.onVote(
                         new VoteResult(getItem(holder.getAdapterPosition()), Constant.RIGHT))));
     }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedFragment.java
@@ -50,4 +50,9 @@ public class FeedFragment extends BaseFragment<FragmentFeedBinding, FeedViewMode
         return R.layout.fragment_feed;
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        viewModel.loadFeedList();
+    }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewModel.java
@@ -1,5 +1,7 @@
 package com.boostcamp.dreampicker.presentation.feed.main;
 
+import android.util.Log;
+
 import com.boostcamp.dreampicker.data.model.Feed;
 import com.boostcamp.dreampicker.data.source.FeedDataSource;
 import com.boostcamp.dreampicker.presentation.BaseViewModel;
@@ -18,7 +20,6 @@ public class FeedViewModel extends BaseViewModel {
 
     FeedViewModel(@NonNull FeedDataSource feedRepository) {
         this.feedRepository = feedRepository;
-        loadFeedList();
     }
 
     // Todo : Firebase 투표 반영
@@ -63,7 +64,8 @@ public class FeedViewModel extends BaseViewModel {
         this.feedList.postValue(feedList);
     }
 
-    private void loadFeedList() {
+    void loadFeedList() {
+        Log.d("Melon", "loadFeedList() 호출");
         addDisposable(feedRepository.getAllFeed()
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(this.feedList::setValue));

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/listener/VoteIconTouchListener.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/listener/VoteIconTouchListener.java
@@ -12,7 +12,7 @@ public class VoteIconTouchListener implements View.OnTouchListener {
     public boolean onTouch(View v, MotionEvent event) {
         if(event.getAction() == MotionEvent.ACTION_DOWN) {
             // 태그 생성
-            final ClipData.Item item = new ClipData.Item((CharSequence) v.getTag());
+            final ClipData.Item item = new ClipData.Item("");
             final String[] mimeTypes = {ClipDescription.MIMETYPE_TEXT_PLAIN};
             final ClipData data = new ClipData(v.getTag().toString(), mimeTypes, item);
 

--- a/app/src/main/java/com/boostcamp/dreampicker/utils/BindingUtil.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/utils/BindingUtil.java
@@ -1,5 +1,7 @@
 package com.boostcamp.dreampicker.utils;
 
+import android.widget.CheckBox;
+
 import com.akexorcist.roundcornerprogressbar.RoundCornerProgressBar;
 
 import java.util.ArrayList;
@@ -30,6 +32,13 @@ public class BindingUtil {
         final List<String> tagItems = Arrays.asList(tagGroup.getTags());
         if(!tagItems.containsAll(items)) {
             tagGroup.setTags(items);
+        }
+    }
+
+    @BindingAdapter({"vote"})
+    public static void doVote(@NonNull CheckBox checkBox, @Constant.VoteFlag int flag) {
+        if(!checkBox.isChecked() && flag != Constant.NONE) {
+            checkBox.performClick();
         }
     }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/utils/BindingUtil.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/utils/BindingUtil.java
@@ -3,6 +3,7 @@ package com.boostcamp.dreampicker.utils;
 import com.akexorcist.roundcornerprogressbar.RoundCornerProgressBar;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -26,7 +27,10 @@ public class BindingUtil {
 
     @BindingAdapter({"tagItems"})
     public static void setTagItems(@NonNull TagGroup tagGroup, @NonNull final List<String> items) {
-        tagGroup.setTags(items);
+        final List<String> tagItems = Arrays.asList(tagGroup.getTags());
+        if(!tagItems.containsAll(items)) {
+            tagGroup.setTags(items);
+        }
     }
 
     @BindingAdapter({"rcProgress"})

--- a/app/src/main/res/drawable/ic_box.xml
+++ b/app/src/main/res/drawable/ic_box.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="24dp"
-        android:height="24dp"
-        android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.11,0 2,-0.9 2,-2L21,5c0,-1.1 -0.89,-2 -2,-2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
-</vector>

--- a/app/src/main/res/layout/item_feed.xml
+++ b/app/src/main/res/layout/item_feed.xml
@@ -17,6 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:cardCornerRadius="5dp"
+            app:cardElevation="5dp"
             app:cardUseCompatPadding="true">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -62,17 +63,17 @@
                     app:layout_constraintBottom_toTopOf="@+id/guideline_feed_top_ver"
                     app:layout_constraintStart_toEndOf="@+id/iv_user_img" />
 
-                <TextView
+                <CheckBox
                     android:id="@+id/tv_feed_vote_count"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_x_small"
                     android:layout_marginEnd="@dimen/space_median"
                     android:layout_marginBottom="@dimen/space_x_small"
-                    android:drawableStart="@drawable/ic_box"
-                    android:drawablePadding="@dimen/space_x_small"
+                    android:clickable="false"
                     android:text="@{String.valueOf(feed.voteCount)}"
                     android:textSize="@dimen/text_title_size"
+                    app:vote="@{feed.voteFlag}"
                     app:layout_constraintBottom_toTopOf="@+id/guideline_feed_top_ver"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_feed.xml
+++ b/app/src/main/res/layout/item_feed.xml
@@ -122,77 +122,60 @@
                     app:small_shine_offset_angle="20" />
 
                 <!-- 피드 하단 부분 -->
-                <View
-                    android:id="@+id/border"
-                    android:layout_width="2dp"
+                <androidx.constraintlayout.widget.Guideline
+                    android:id="@+id/guideline_feed_image_ho"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintGuide_percent="0.5" />
+
+                <ImageView
+                    android:id="@+id/iv_feed_image_left"
+                    android:layout_width="0dp"
                     android:layout_height="@dimen/feed_photo_image_height"
-                    android:layout_marginTop="@dimen/space_x_small"
-                    android:background="@android:color/darker_gray"
-                    app:layout_constraintBottom_toTopOf="@+id/vote_result"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_feed_content" />
-
-                <FrameLayout
-                    android:id="@+id/fl_feed_left"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
-                    android:layout_marginTop="@dimen/space_x_small"
+                    android:scaleType="fitXY"
                     android:tag="@{feed.id}"
-                    app:layout_constraintBottom_toTopOf="@+id/vote_result"
-                    app:layout_constraintEnd_toStartOf="@+id/border"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_feed_content">
-
-                    <ImageView
-                        android:id="@+id/iv_feed_image_left"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:scaleType="fitXY"
-                        app:imageResource="@{feed.imageList.get(0).image}" />
-
-                    <TextView
-                        android:id="@+id/tv_feed_tag_left"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="start|bottom"
-                        android:layout_marginStart="@dimen/space_x_small"
-                        android:layout_marginBottom="@dimen/space_x_small"
-                        android:text="@{feed.imageList.get(0).tag}"
-                        android:textColor="@android:color/white"
-                        android:textStyle="bold"
-                        tools:layout_editor_absoluteX="8dp" />
-                </FrameLayout>
-
-                <FrameLayout
-                    android:id="@+id/fl_feed_right"
-                    android:layout_width="0dp"
-                    android:layout_height="0dp"
                     android:layout_marginTop="@dimen/space_x_small"
+                    app:imageResource="@{feed.imageList.get(0).image}"
+                    app:layout_constraintBottom_toTopOf="@id/vote_result"
+                    app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_feed_content"/>
+
+                <me.gujun.android.taggroup.TagGroup
+                    android:id="@+id/tv_feed_tag_left"
+                    style="@style/TagGroup.Small"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/feed_tag_group_height"
+                    android:layout_margin="@dimen/space_x_small"
+                    app:tagItems="@{feed.imageList.get(0).tagList}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/guideline_feed_image_ho"
+                    app:layout_constraintBottom_toTopOf="@id/vote_result"/>
+
+                <ImageView
+                    android:id="@+id/iv_feed_image_right"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/feed_photo_image_height"
+                    android:scaleType="fitXY"
                     android:tag="@{feed.id}"
-                    app:layout_constraintBottom_toTopOf="@+id/vote_result"
+                    android:layout_marginTop="@dimen/space_x_small"
+                    app:imageResource="@{feed.imageList.get(1).image}"
+                    app:layout_constraintBottom_toTopOf="@id/vote_result"
+                    app:layout_constraintStart_toEndOf="@+id/guideline_feed_image_ho"
+                    app:layout_constraintTop_toBottomOf="@id/tv_feed_content"
+                    app:layout_constraintEnd_toEndOf="parent"/>
+
+                <me.gujun.android.taggroup.TagGroup
+                    android:id="@+id/tv_feed_tag_right"
+                    style="@style/TagGroup.Small"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/feed_tag_group_height"
+                    android:layout_margin="@dimen/space_x_small"
+                    app:tagItems="@{feed.imageList.get(1).tagList}"
+                    app:layout_constraintStart_toEndOf="@id/guideline_feed_image_ho"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@+id/border"
-                    app:layout_constraintTop_toBottomOf="@+id/tv_feed_content">
-
-                    <ImageView
-                        android:id="@+id/iv_feed_image_right"
-                        android:layout_width="match_parent"
-                        android:layout_height="match_parent"
-                        android:scaleType="fitXY"
-                        app:imageResource="@{feed.imageList.get(1).image}" />
-
-                    <TextView
-                        android:id="@+id/tv_feed_tag_right"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="start|bottom"
-                        android:layout_marginStart="@dimen/space_x_small"
-                        android:layout_marginBottom="@dimen/space_x_small"
-                        android:text="@{feed.imageList.get(1).tag}"
-                        android:textColor="@android:color/white"
-                        android:textStyle="bold" />
-                </FrameLayout>
+                    app:layout_constraintBottom_toTopOf="@id/vote_result"/>
 
                 <!-- 피드 결과 -->
                 <LinearLayout

--- a/app/src/main/res/layout/item_feed_vote_left.xml
+++ b/app/src/main/res/layout/item_feed_vote_left.xml
@@ -69,6 +69,7 @@
         android:id="@+id/sb_selector"
         android:layout_width="56dp"
         android:layout_height="56dp"
+        android:layout_marginStart="8dp"
         android:background="@drawable/ic_vote_bg"
         android:clickable="false"
         android:elevation="5dp"
@@ -78,8 +79,8 @@
         app:click_animation_duration="200"
         app:enable_flashing="false"
         app:layout_constraintBottom_toTopOf="@+id/vote_result"
-        app:layout_constraintEnd_toStartOf="@+id/border"
-        app:layout_constraintStart_toStartOf="@+id/fl_feed_left"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tv_feed_content"
         app:shine_animation_duration="1500"
         app:shine_count="8"
@@ -89,68 +90,54 @@
         app:small_shine_offset_angle="20" />
 
     <!-- 피드 하단 부분 -->
-    <View
-        android:id="@+id/border"
-        android:layout_width="2dp"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_feed_image_ho"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <ImageView
+        android:id="@+id/iv_feed_image_left"
+        android:layout_width="0dp"
         android:layout_height="@dimen/feed_photo_image_height"
+        android:scaleType="fitXY"
         android:layout_marginTop="@dimen/space_x_small"
-        android:background="@android:color/darker_gray"
-        app:layout_constraintBottom_toTopOf="@+id/vote_result"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/vote_result"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_feed_content" />
+        app:layout_constraintTop_toBottomOf="@id/tv_feed_content"/>
 
-    <FrameLayout
-        android:id="@+id/fl_feed_left"
+    <me.gujun.android.taggroup.TagGroup
+        android:id="@+id/tv_feed_tag_left"
+        style="@style/TagGroup.Small"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="@dimen/space_x_small"
-        app:layout_constraintBottom_toTopOf="@+id/vote_result"
-        app:layout_constraintEnd_toStartOf="@+id/border"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_feed_content">
+        android:layout_height="@dimen/feed_tag_group_height"
+        android:layout_margin="@dimen/space_x_small"
+        app:layout_constraintBottom_toBottomOf="@id/iv_feed_image_left"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <ImageView
-            android:id="@+id/iv_feed_image_left"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="fitXY" />
-
-        <TextView
-            android:id="@+id/tv_feed_tag_left"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|bottom"
-            android:layout_marginStart="@dimen/space_x_small"
-            android:layout_marginBottom="@dimen/space_x_small"
-            android:textColor="@android:color/white"
-            android:textStyle="bold" />
-    </FrameLayout>
-
-    <FrameLayout
-        android:id="@+id/fl_feed_right"
+    <ImageView
+        android:id="@+id/iv_feed_image_right"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="@dimen/feed_photo_image_height"
+        android:scaleType="fitXY"
         android:layout_marginTop="@dimen/space_x_small"
-        app:layout_constraintBottom_toTopOf="@+id/vote_result"
+        app:layout_constraintBottom_toTopOf="@id/vote_result"
+        app:layout_constraintStart_toEndOf="@+id/guideline_feed_image_ho"
+        app:layout_constraintTop_toBottomOf="@id/tv_feed_content"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <me.gujun.android.taggroup.TagGroup
+        android:id="@+id/tv_feed_tag_right"
+        style="@style/TagGroup.Small"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/feed_tag_group_height"
+        android:layout_margin="@dimen/space_x_small"
+        app:layout_constraintStart_toEndOf="@id/guideline_feed_image_ho"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/border"
-        app:layout_constraintTop_toBottomOf="@+id/tv_feed_content">
-
-        <ImageView
-            android:id="@+id/iv_feed_image_right"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="fitXY" />
-
-        <TextView
-            android:id="@+id/tv_feed_tag_right"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|bottom"
-            android:layout_marginStart="@dimen/space_x_small"
-            android:layout_marginBottom="@dimen/space_x_small" />
-    </FrameLayout>
+        app:layout_constraintBottom_toTopOf="@id/vote_result"/>
 
     <!-- 피드 결과 -->
     <LinearLayout

--- a/app/src/main/res/layout/item_feed_vote_left.xml
+++ b/app/src/main/res/layout/item_feed_vote_left.xml
@@ -36,15 +36,13 @@
         app:layout_constraintBottom_toTopOf="@+id/guideline_feed_top_ver"
         app:layout_constraintStart_toEndOf="@+id/iv_user_img" />
 
-    <TextView
+    <CheckBox
         android:id="@+id/tv_feed_vote_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/space_x_small"
         android:layout_marginEnd="@dimen/space_median"
         android:layout_marginBottom="@dimen/space_x_small"
-        android:drawableStart="@drawable/ic_box"
-        android:drawablePadding="@dimen/space_x_small"
         app:layout_constraintBottom_toTopOf="@+id/guideline_feed_top_ver"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/item_feed_vote_right.xml
+++ b/app/src/main/res/layout/item_feed_vote_right.xml
@@ -81,7 +81,7 @@
         app:enable_flashing="false"
         app:layout_constraintBottom_toTopOf="@+id/vote_result"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/border"
+        app:layout_constraintStart_toEndOf="@+id/guideline_feed_image_ho"
         app:layout_constraintTop_toBottomOf="@+id/tv_feed_content"
         app:shine_animation_duration="1500"
         app:shine_count="8"
@@ -91,68 +91,54 @@
         app:small_shine_offset_angle="20" />
 
     <!-- 피드 하단 부분 -->
-    <View
-        android:id="@+id/border"
-        android:layout_width="2dp"
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline_feed_image_ho"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <ImageView
+        android:id="@+id/iv_feed_image_left"
+        android:layout_width="0dp"
         android:layout_height="@dimen/feed_photo_image_height"
+        android:scaleType="fitXY"
         android:layout_marginTop="@dimen/space_x_small"
-        android:background="@android:color/darker_gray"
-        app:layout_constraintBottom_toTopOf="@+id/vote_result"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/vote_result"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_feed_content" />
+        app:layout_constraintTop_toBottomOf="@id/tv_feed_content"/>
 
-    <FrameLayout
-        android:id="@+id/fl_feed_left"
+    <me.gujun.android.taggroup.TagGroup
+        android:id="@+id/tv_feed_tag_left"
+        style="@style/TagGroup.Small"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="@dimen/space_x_small"
-        app:layout_constraintBottom_toTopOf="@+id/vote_result"
-        app:layout_constraintEnd_toStartOf="@+id/border"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/tv_feed_content">
+        android:layout_height="@dimen/feed_tag_group_height"
+        android:layout_margin="@dimen/space_x_small"
+        app:layout_constraintBottom_toBottomOf="@id/iv_feed_image_left"
+        app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <ImageView
-            android:id="@+id/iv_feed_image_left"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="fitXY" />
-
-        <TextView
-            android:id="@+id/tv_feed_tag_left"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|bottom"
-            android:layout_marginStart="@dimen/space_x_small"
-            android:layout_marginBottom="@dimen/space_x_small"
-            android:textColor="@android:color/white"
-            android:textStyle="bold" />
-    </FrameLayout>
-
-    <FrameLayout
-        android:id="@+id/fl_feed_right"
+    <ImageView
+        android:id="@+id/iv_feed_image_right"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="@dimen/feed_photo_image_height"
+        android:scaleType="fitXY"
         android:layout_marginTop="@dimen/space_x_small"
-        app:layout_constraintBottom_toTopOf="@+id/vote_result"
+        app:layout_constraintBottom_toTopOf="@id/vote_result"
+        app:layout_constraintStart_toEndOf="@+id/guideline_feed_image_ho"
+        app:layout_constraintTop_toBottomOf="@id/tv_feed_content"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <me.gujun.android.taggroup.TagGroup
+        android:id="@+id/tv_feed_tag_right"
+        style="@style/TagGroup.Small"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/feed_tag_group_height"
+        android:layout_margin="@dimen/space_x_small"
+        app:layout_constraintStart_toEndOf="@id/guideline_feed_image_ho"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/border"
-        app:layout_constraintTop_toBottomOf="@+id/tv_feed_content">
-
-        <ImageView
-            android:id="@+id/iv_feed_image_right"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scaleType="fitXY" />
-
-        <TextView
-            android:id="@+id/tv_feed_tag_right"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="start|bottom"
-            android:layout_marginStart="@dimen/space_x_small"
-            android:layout_marginBottom="@dimen/space_x_small" />
-    </FrameLayout>
+        app:layout_constraintBottom_toTopOf="@id/vote_result"/>
 
     <!-- 피드 결과 -->
     <LinearLayout

--- a/app/src/main/res/layout/item_feed_vote_right.xml
+++ b/app/src/main/res/layout/item_feed_vote_right.xml
@@ -36,15 +36,13 @@
         app:layout_constraintBottom_toTopOf="@+id/guideline_feed_top_ver"
         app:layout_constraintStart_toEndOf="@+id/iv_user_img" />
 
-    <TextView
+    <CheckBox
         android:id="@+id/tv_feed_vote_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/space_x_small"
         android:layout_marginEnd="@dimen/space_median"
         android:layout_marginBottom="@dimen/space_x_small"
-        android:drawableStart="@drawable/ic_box"
-        android:drawablePadding="@dimen/space_x_small"
         app:layout_constraintBottom_toTopOf="@+id/guideline_feed_top_ver"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -30,8 +30,9 @@
     <dimen name="profile_image_size_median">60dp</dimen>
     <dimen name="profile_image_size_large">80dp</dimen>
 
-    <!-- Feed Image Size -->
+    <!-- Feed Main -->
     <dimen name="feed_photo_image_height">200dp</dimen>
+    <dimen name="feed_tag_group_height">20dp</dimen>
 
     <!-- 특정 화면에서 쓰이는 dimen -->
     <dimen name="profile_tab_height">40dp</dimen>


### PR DESCRIPTION
﻿### 개요
- 메인피드에서 보여지는 태그를 `tagGroup`을 이용해 리스트로 표현

<hr>

### 상세내용 
- 이슈에서 목표로한 `ScrollView`의 기능이 충돌이 많이 나서 `ConstraintLayout`으로 바로 표현합니다.
- 메인 피드 화면에서는 태그는 1줄로만 표시가 됩니다.
(이후 상세보기에서 모든 태그를 표시할 계획입니다.
- 투표수에 대한 텍스트뷰를 체크박스로 변경하였습니다.
- 특정 상황에 대해 피드를 갱신해야할 필요가 있어 `onResume`으로 호출을 변경하였습니다.
**( 현재는 Mock 데이터이기 때문에 홈으로 갔다와도 초기화가 이상하게 됩니다. )**

### 체크리스트
- [x] `ScrollView` 사용 -> `ConstraintLayout` 대체
- [x] `TagGroup` 사용

<hr>

### 스크린샷
<div>
<img src="https://user-images.githubusercontent.com/28249981/52328059-aadec100-2a31-11e9-8b60-1a57d8890d19.png" width=240 height=360/> &nbsp;
</div>

<hr>

- resolved : #95 
- resolved : #96 