### PR TITLE
업로드 인터페이스, 로직 추가

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/MyProfileDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/MyProfileDataSource.java
@@ -1,0 +1,11 @@
+package com.boostcamp.dreampicker.data.source;
+
+
+import com.boostcamp.dreampicker.data.model.User;
+
+import io.reactivex.Single;
+
+// Todo : 이 데이터 소스는 이후 유저로 변경 예정
+public interface MyProfileDataSource {
+    Single<User> getMyProfile();
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/UploadDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/UploadDataSource.java
@@ -1,0 +1,10 @@
+package com.boostcamp.dreampicker.data.source;
+
+import com.boostcamp.dreampicker.data.model.Feed;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Completable;
+
+public interface UploadDataSource {
+    Completable upload(@NonNull Feed feed);
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/ProfileMockDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/ProfileMockDataSource.java
@@ -1,0 +1,22 @@
+package com.boostcamp.dreampicker.data.source.local.test;
+
+
+import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.data.model.User;
+import com.boostcamp.dreampicker.data.source.MyProfileDataSource;
+
+import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
+
+// Test용 임식 클래스
+public class ProfileMockDataSource implements MyProfileDataSource {
+    @Override
+    public Single<User> getMyProfile() {
+        User user = new User("yoon",
+                "라이언",
+                "http://monthly.chosun.com/up_fd/Mdaily/2017-09/bimg_thumb/2017042000056_0.jpg",
+                R.drawable.profile);
+
+        return Single.just(user).subscribeOn(Schedulers.io());
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/UploadMockDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/UploadMockDataSource.java
@@ -1,0 +1,39 @@
+package com.boostcamp.dreampicker.data.source.local.test;
+
+import android.util.Log;
+
+import com.boostcamp.dreampicker.data.model.Feed;
+import com.boostcamp.dreampicker.data.source.UploadDataSource;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Completable;
+import io.reactivex.schedulers.Schedulers;
+
+public class UploadMockDataSource implements UploadDataSource {
+    private static final String TAG = "Melon";
+    @NonNull
+    @Override
+    public Completable upload(@NonNull Feed feed) {
+        return Completable.create(emitter -> {
+            Log.d(TAG, "---------------------------------------");
+            Log.d(TAG, "Feed 출력 정보");
+            Log.d(TAG, "Feed id : " + feed.getId());
+            Log.d(TAG, "Feed content : " + feed.getContent());
+            Log.d(TAG, "Feed date : " + feed.getDate());
+            Log.d(TAG, "Uploader id : " + feed.getUser().getId());
+            Log.d(TAG, "Uploader name : " + feed.getUser().getName());
+            Log.d(TAG, "Uploader name : " + feed.getUser().getProfileImageUrl());
+            Log.d(TAG, "Image[0] uri : " + feed.getImageList().get(0).getUri());
+            Log.d(TAG, "Image[0] tagList " + feed.getImageList().get(0).getTagList());
+            Log.d(TAG, "Image[1] uri : " + feed.getImageList().get(1).getUri());
+            Log.d(TAG, "Image[1] tagList " + feed.getImageList().get(1).getTagList());
+            Log.d(TAG, "Feed leftCount : " + feed.getLeftCount());
+            Log.d(TAG, "Feed rightCount : " + feed.getRightCount());
+            Log.d(TAG, "Feed totalCount : " + feed.getVoteCount());
+            Log.d(TAG, "Feed voteFlag : " + feed.getVoteFlag());
+            Log.d(TAG, "---------------------------------------");
+
+            emitter.onComplete();
+        }).subscribeOn(Schedulers.io());
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadActivity.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadActivity.java
@@ -8,6 +8,8 @@ import android.widget.ImageButton;
 import android.widget.Toast;
 
 import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.data.source.local.test.ProfileMockDataSource;
+import com.boostcamp.dreampicker.data.source.local.test.UploadMockDataSource;
 import com.boostcamp.dreampicker.databinding.ActivityUploadBinding;
 import com.boostcamp.dreampicker.presentation.BaseActivity;
 import com.boostcamp.dreampicker.utils.Constant;
@@ -38,7 +40,8 @@ public class UploadActivity extends BaseActivity<ActivityUploadBinding> {
     }
 
     private void initViewModel() {
-        final UploadViewModel viewModel = ViewModelProviders.of(this).get(UploadViewModel.class);
+        /*final UploadViewModel viewModel = ViewModelProviders.of(this).get(UploadViewModel.class);*/
+        final UploadViewModel viewModel = new UploadViewModel(new UploadMockDataSource(), new ProfileMockDataSource());
         binding.setViewModel(viewModel);
         binding.setLifecycleOwner(this);
     }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadActivity.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadActivity.java
@@ -10,6 +10,10 @@ import android.widget.Toast;
 import com.boostcamp.dreampicker.R;
 import com.boostcamp.dreampicker.data.source.local.test.ProfileMockDataSource;
 import com.boostcamp.dreampicker.data.source.local.test.UploadMockDataSource;
+import com.boostcamp.dreampicker.data.source.remote.firebase.FeedFirebaseService;
+import com.boostcamp.dreampicker.data.source.remote.firebase.UserFirebaseService;
+import com.boostcamp.dreampicker.data.source.repository.FeedRepository;
+import com.boostcamp.dreampicker.data.source.repository.UserRepository;
 import com.boostcamp.dreampicker.databinding.ActivityUploadBinding;
 import com.boostcamp.dreampicker.presentation.BaseActivity;
 import com.boostcamp.dreampicker.utils.Constant;
@@ -40,8 +44,14 @@ public class UploadActivity extends BaseActivity<ActivityUploadBinding> {
     }
 
     private void initViewModel() {
-        /*final UploadViewModel viewModel = ViewModelProviders.of(this).get(UploadViewModel.class);*/
-        final UploadViewModel viewModel = new UploadViewModel(new UploadMockDataSource(), new ProfileMockDataSource());
+        final UploadViewModel viewModel = ViewModelProviders.of(this,
+                new UploadViewModelFactory(
+                        FeedRepository.getInstance(FeedFirebaseService.getInstance()),
+                        UserRepository.getInstance(UserFirebaseService.getInstance())))
+                .get(UploadViewModel.class);
+
+        // final UploadViewModel viewModel = new UploadViewModel(new UploadMockDataSource(), new ProfileMockDataSource());
+
         binding.setViewModel(viewModel);
         binding.setLifecycleOwner(this);
     }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadViewModel.java
@@ -4,46 +4,47 @@ import android.annotation.SuppressLint;
 import android.net.Uri;
 import android.text.TextUtils;
 
-import com.boostcamp.dreampicker.R;
 import com.boostcamp.dreampicker.data.model.Feed;
 import com.boostcamp.dreampicker.data.model.Image;
 import com.boostcamp.dreampicker.data.model.User;
+import com.boostcamp.dreampicker.data.source.MyProfileDataSource;
+import com.boostcamp.dreampicker.data.source.UploadDataSource;
 import com.boostcamp.dreampicker.presentation.BaseViewModel;
 import com.boostcamp.dreampicker.utils.Constant;
+import com.boostcamp.dreampicker.utils.IdCreator;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
 import androidx.annotation.NonNull;
 import androidx.databinding.ObservableField;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import io.reactivex.android.schedulers.AndroidSchedulers;
 
 public class UploadViewModel extends BaseViewModel {
-    private static final String TYPE_FEED = "feed-";
-    private static final String TYPE_IMAGE = "image-";
-    private static final String TYPE_USER = "user-";
-
-    @SuppressLint("SimpleDateFormat")
-    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-
     private MutableLiveData<List<Image>> imageList = new MutableLiveData<>();
     private ObservableField<String> content = new ObservableField<>();
 
     private MutableLiveData<Boolean> validate = new MutableLiveData<>();
 
-    UploadViewModel() {
+    private final UploadDataSource uploadDataSource;
+    private final MyProfileDataSource myProfileDataSource;
+
+    UploadViewModel(UploadDataSource uploadDataSource, MyProfileDataSource myProfileDataSource) {
+        this.uploadDataSource = uploadDataSource;
+        this.myProfileDataSource = myProfileDataSource;
+
         imageList.setValue(Arrays.asList(new Image(), new Image()));
     }
 
     void setImage(@NonNull Uri uri, @Constant.VoteFlag int flag) {
         final List<Image> imageList = this.imageList.getValue();
         if (imageList != null) {
-            imageList.set(flag - 1, new Image(createId(TYPE_IMAGE), uri, new ArrayList<>()));
+            imageList.set(flag - 1, new Image(IdCreator.createImageId(), uri, new ArrayList<>()));
             this.imageList.postValue(imageList);
         }
     }
@@ -67,9 +68,6 @@ public class UploadViewModel extends BaseViewModel {
 
     // Todo : Firebase에 업로드 연동 필요
     // Todo : 유저 정보 가져오는법 파악 필요
-    // Todo : 유저를 이곳에서 생성할지 중간 매개가 있을지 고민 필요
-    // Todo : 유저를 중간에서 생성한다면 피드도 그곳에서 같이 생성됨 !!
-    // Todo : 넘겨줘야 한다면 FeedRequestData 안에 이미지, 피드정보 담아서 보낼 예정
     void upload() {
         final List<Image> imageList = this.imageList.getValue();
 
@@ -78,20 +76,31 @@ public class UploadViewModel extends BaseViewModel {
                 !TextUtils.isEmpty(imageList.get(1).getId()) &&
                 !TextUtils.isEmpty(content.get())) {
 
-            final Feed feed = new Feed();
-            feed.setId(createId(TYPE_FEED));
-            feed.setUser(new User(TYPE_USER, "윤OO", R.drawable.profile3));
-            feed.setContent(content.get());
-            feed.setImageList(imageList);
-            feed.setDate(dateFormat.format(new Date()));
-            validate.setValue(true);
+            addDisposable(myProfileDataSource.getMyProfile()
+                    .flatMapCompletable(user -> {
+                        final Feed feed = createFeed(user, imageList);
+                        return uploadDataSource.upload(feed);
+                    })
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribe(
+                            () -> validate.setValue(true),
+                            e -> validate.setValue(false)));
         } else {
             validate.setValue(false);
         }
     }
 
-    private String createId(String type) {
-        return type + UUID.randomUUID().toString();
+    @NonNull
+    @SuppressLint("SimpleDateFormat")
+    private Feed createFeed(@NonNull User user, @NonNull final List<Image> imageList) {
+        final Feed feed = new Feed();
+        feed.setId(IdCreator.createFeedId());
+        feed.setUser(user);
+        feed.setContent(content.get());
+        feed.setImageList(imageList);
+        feed.setDate(new SimpleDateFormat("yyyy-MM-dd").format(new Date()));
+
+        return feed;
     }
 
     public LiveData<List<Image>> getImageList() {

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadViewModelFactory.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadViewModelFactory.java
@@ -1,0 +1,34 @@
+package com.boostcamp.dreampicker.presentation.upload;
+
+import com.boostcamp.dreampicker.data.source.FeedDataSource;
+import com.boostcamp.dreampicker.data.source.UserDataSource;
+import com.boostcamp.dreampicker.data.source.local.test.ProfileMockDataSource;
+import com.boostcamp.dreampicker.data.source.local.test.UploadMockDataSource;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+public class UploadViewModelFactory implements ViewModelProvider.Factory {
+    private final FeedDataSource feedRepository;
+    private final UserDataSource userRepositry;
+
+    UploadViewModelFactory(FeedDataSource feedRepository, UserDataSource userRepositry) {
+        this.feedRepository = feedRepository;
+        this.userRepositry = userRepositry;
+    }
+
+    @NonNull
+    @Override
+    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+        if(modelClass.isAssignableFrom(UploadViewModel.class)) {
+            //noinspection unchecked
+            // Todo : 인터페이스 변경시 수정
+            return (T) new UploadViewModel(new UploadMockDataSource(), new ProfileMockDataSource());
+            //return (T) new UploadViewModel(feedRepository, userRepositry);
+        } else {
+            throw new IllegalArgumentException("ViewModel Not Found");
+        }
+    }
+
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/utils/IdCreator.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/utils/IdCreator.java
@@ -1,0 +1,20 @@
+package com.boostcamp.dreampicker.utils;
+
+import java.util.UUID;
+
+public class IdCreator {
+    private static final String TYPE_FEED = "feed-";
+    private static final String TYPE_IMAGE = "image-";
+
+    public static String createFeedId() {
+        return TYPE_FEED + createUUID();
+    }
+
+    public static String createImageId() {
+        return TYPE_IMAGE + createUUID();
+    }
+
+    private static String createUUID() {
+        return UUID.randomUUID().toString();
+    }
+}


### PR DESCRIPTION
﻿### 개요
- 업로드 과정에 대한 인터페이스, 데이터소스 모델을 구성

<hr>

### 상세 내용
- 임시로 `ProfileMockDataSource`, `UploadMockDataSource` 등을 추가하였습니다.
- 업로드 -> 피드 || 프로필 가져오기 -> 유저 쪽으로 이동 해주시면 됩니다.
- `UUID`를 가져오기 위한 `IdCreator`를 제작하였습니다. 이후 아이디 규칙이 변경되면 수정하겠습니다.

<hr>

- resolved : #111 