### PR TITLE
검색 - 페이징 처리 

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/UserMockDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/UserMockDataSource.java
@@ -50,7 +50,11 @@ public class UserMockDataSource implements UserDataSource {
                                                                    int display) {
         List<User> userList = new ArrayList<>();
         for (int i = 0; i < display; i++) {
-            User user = new User("", "yeseul", R.drawable.profile);
+            User user = new User(
+                    userId,
+                    "yeseul",
+                    "https://img.sbs.co.kr/newimg/news/20170622/201061239_1280.jpg",
+                    R.drawable.profile);
             userList.add(user);
         }
         return Single.just(new PagedListResponse<>(start, display, userList));
@@ -63,7 +67,11 @@ public class UserMockDataSource implements UserDataSource {
                                                                   int display) {
         List<User> userList = new ArrayList<>();
         for (int i = 0; i < display; i++) {
-            User user = new User("", "yeseul", R.drawable.profile);
+            User user = new User(
+                    userId,
+                    "yeseul",
+                    "https://img.sbs.co.kr/newimg/news/20170622/201061239_1280.jpg",
+                    R.drawable.profile);
             userList.add(user);
         }
         return Single.just(new PagedListResponse<>(start, display, userList));
@@ -76,7 +84,11 @@ public class UserMockDataSource implements UserDataSource {
                                                              int display) {
         List<User> userList = new ArrayList<>();
         for (int i = 0; i < display; i++) {
-            User user = new User("", "yeseul", R.drawable.profile);
+            User user = new User(
+                    "",
+                    "yeseul",
+                    "https://img.sbs.co.kr/newimg/news/20170622/201061239_1280.jpg",
+                    R.drawable.profile);
             userList.add(user);
         }
         return Single.just(new PagedListResponse<>(start, display, userList));

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/remote/firebase/response/PagedListResponse.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/remote/firebase/response/PagedListResponse.java
@@ -29,11 +29,11 @@ public class PagedListResponse<T> {
         this.display = display;
     }
 
-    public List<T> getFeedList() {
+    public List<T> getItemList() {
         return feedList;
     }
 
-    public void setFeedList(List<T> feedList) {
+    public void setItemList(List<T> feedList) {
         this.feedList = feedList;
     }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/main/MainActivity.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/main/MainActivity.java
@@ -13,6 +13,7 @@ import com.boostcamp.dreampicker.presentation.notification.NotificationFragment;
 import com.boostcamp.dreampicker.presentation.profile.ProfileFragment;
 import com.boostcamp.dreampicker.presentation.search.SearchFragment;
 import com.boostcamp.dreampicker.presentation.upload.UploadActivity;
+import com.boostcamp.dreampicker.utils.FirebaseManager;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import androidx.annotation.NonNull;
@@ -66,7 +67,7 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> implements B
                 fragment = NotificationFragment.newInstance();
                 break;
             case R.id.navigation_profile:
-                fragment = ProfileFragment.newInstance("");
+                fragment = ProfileFragment.newInstance(FirebaseManager.getCurrentUserId());
                 break;
         }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFeedAdapter.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFeedAdapter.java
@@ -18,7 +18,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 public class ProfileFeedAdapter extends BasePagedListAdapter<Feed, ProfileFeedAdapter.ViewHolder> {
 
-    ProfileFeedAdapter(@Nullable OnItemClickListener<Feed> onItemClickListener) {
+    public ProfileFeedAdapter(@Nullable OnItemClickListener<Feed> onItemClickListener) {
         super(DIFF_CALLBACK, onItemClickListener);
     }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFeedPagedDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFeedPagedDataSource.java
@@ -40,9 +40,11 @@ public class ProfileFeedPagedDataSource extends PageKeyedDataSource<Integer, Fee
         disposable.add(repository.addProfileFeedList(userId, 1, params.requestedLoadSize)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response ->
-                        callback.onResult(response.getFeedList(),
+                        callback.onResult(response.getItemList(),
                                 response.getDisplay(),
-                                response.getStart() + response.getDisplay()))
+                                response.getStart() + response.getDisplay()),
+                        error -> { }
+                )
         );
     }
 
@@ -65,8 +67,10 @@ public class ProfileFeedPagedDataSource extends PageKeyedDataSource<Integer, Fee
         disposable.add(repository.addProfileFeedList(userId, params.key, params.requestedLoadSize)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(response ->
-                        callback.onResult(response.getFeedList(),
-                                params.key + response.getDisplay()))
+                                callback.onResult(response.getItemList(),
+                                        params.key + response.getDisplay()),
+                        error -> { }
+                )
         );
     }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFragment.java
@@ -2,7 +2,6 @@ package com.boostcamp.dreampicker.presentation.profile;
 
 import android.os.Bundle;
 import android.view.View;
-import android.widget.Toast;
 
 import com.boostcamp.dreampicker.R;
 import com.boostcamp.dreampicker.data.model.Feed;
@@ -21,10 +20,9 @@ import androidx.lifecycle.ViewModelProviders;
 public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
     private static final String ARGUMENT_USER_ID = "ARGUMENT_USER_ID";
 
-    public ProfileFragment() {
-    }
+    public ProfileFragment() { }
 
-    public static ProfileFragment newInstance(@NonNull String userId) {
+    public static ProfileFragment newInstance(@Nullable String userId) {
         ProfileFragment fragment = new ProfileFragment();
         Bundle args = new Bundle();
         args.putString(ARGUMENT_USER_ID, userId);
@@ -43,6 +41,7 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        // TODO. userId=null 인 경우 예외처리
         if (savedInstanceState != null) {
             userId = savedInstanceState.getString(ARGUMENT_USER_ID);
         } else {
@@ -62,7 +61,7 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
 
     private void initViewModel() {
         // 프로필 정보 담고있는 뷰모델
-        ProfileViewModel viewModel = ViewModelProviders.of(this,
+        final ProfileViewModel viewModel = ViewModelProviders.of(this,
                 new ProfileViewModel.Factory(
                         UserRepository.getInstance(UserFirebaseService.getInstance()),
                         userId
@@ -71,7 +70,7 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
         binding.getVm().getError().observe(this, Throwable::printStackTrace);
 
         // 피드 목록 담고있는 뷰모델
-        ProfileFeedViewModel feedViewModel = ViewModelProviders.of(this,
+        final ProfileFeedViewModel feedViewModel = ViewModelProviders.of(this,
                 new ProfileFeedViewModel.Factory(
                         FeedRepository.getInstance(FeedFirebaseService.getInstance()),
                         userId
@@ -100,8 +99,6 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
     private void initRecyclerView() {
         ProfileFeedAdapter adapter = new ProfileFeedAdapter(this::startFeedDetailActivity);
         binding.recyclerProfileFeed.setAdapter(adapter);
-
-        binding.getFeedVm().feedPagedList.observe(this, adapter::submitList);
     }
 
     private void initCountingView() {
@@ -114,6 +111,6 @@ public class ProfileFragment extends BaseFragment<FragmentProfileBinding> {
     }
 
     private void startFeedDetailActivity(Feed feed) {
-        Toast.makeText(getContext(), "item Clicked: " + feed.getId(), Toast.LENGTH_SHORT).show();
+        // TODO. 피드 상세 페이지 띄우기
     }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/OnSearchListener.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/OnSearchListener.java
@@ -1,0 +1,8 @@
+package com.boostcamp.dreampicker.presentation.search;
+
+import androidx.annotation.Nullable;
+
+public interface OnSearchListener {
+    void onSearch(@Nullable String searchKey);
+}
+

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/SearchFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/SearchFragment.java
@@ -99,6 +99,10 @@ public class SearchFragment extends BaseFragment<FragmentSearchBinding> {
 
         public SearchPagerAdapter(@NonNull FragmentManager fm) {
             super(fm);
+            fragments[0] = SearchUserFragment.newInstance();
+            fragments[1] = SearchFeedFragment.newInstance();
+            onSearchListeners.add((OnSearchListener) fragments[0]);
+            onSearchListeners.add((OnSearchListener) fragments[1]);
         }
 
         @NonNull

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/SearchFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/SearchFragment.java
@@ -1,36 +1,38 @@
 package com.boostcamp.dreampicker.presentation.search;
 
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 
 import com.boostcamp.dreampicker.R;
-import com.boostcamp.dreampicker.data.source.remote.firebase.FeedFirebaseService;
-import com.boostcamp.dreampicker.data.source.repository.FeedRepository;
 import com.boostcamp.dreampicker.databinding.FragmentSearchBinding;
 import com.boostcamp.dreampicker.presentation.BaseFragment;
-import com.boostcamp.dreampicker.presentation.profile.ProfileFragment;
+import com.boostcamp.dreampicker.presentation.search.feed.SearchFeedFragment;
+import com.boostcamp.dreampicker.presentation.search.user.SearchUserFragment;
 import com.google.android.material.tabs.TabLayout;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
-import androidx.lifecycle.ViewModelProviders;
 
 public class SearchFragment extends BaseFragment<FragmentSearchBinding> {
 
     private final int NUM_OF_TAB_BUTTONS = 2;
 
-    // TODO. ViewModel 로 이동
-    private FeedRepository repository = FeedRepository.getInstance(FeedFirebaseService.getInstance());
+    private List<OnSearchListener> onSearchListeners = new ArrayList<>();
 
-    private SearchPagerAdapter adapter;
+    public SearchFragment() {
+    }
 
-    public SearchFragment() {}
-
-    public static SearchFragment newInstance(){
+    public static SearchFragment newInstance() {
         return new SearchFragment();
     }
 
@@ -40,30 +42,53 @@ public class SearchFragment extends BaseFragment<FragmentSearchBinding> {
     }
 
     @Override
-    public void onCreate(@Nullable Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        // TODO. argument 넘겨 받은거 처리하는 작업
-    }
-
-    @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
         initView();
     }
 
     private void initView() {
+        initViewPagerTab();
+        initSearchButton();
+    }
 
-        // 뷰페이저 생성
-        adapter = new SearchPagerAdapter(getChildFragmentManager());
-        binding.vpSearch.setAdapter(adapter);
-
-        // 탭 레이아웃 생성
+    private void initViewPagerTab() {
+        binding.vpSearch.setAdapter(new SearchPagerAdapter(getChildFragmentManager()));
         binding.tabSearch.setupWithViewPager(binding.vpSearch);
-        for(int i = 0 ; i < NUM_OF_TAB_BUTTONS ; i++) {
+        for (int i = 0; i < NUM_OF_TAB_BUTTONS; i++) {
             TabLayout.Tab tab = binding.tabSearch.getTabAt(i);
             tab.setText(getResources().getStringArray(R.array.search_tab_names)[i]);
+        }
+    }
+
+    private void initSearchButton() {
+        binding.layoutSearchBar.btnSearch.setOnClickListener(__ ->
+                onSearch(binding.layoutSearchBar.etSearch.getText().toString())
+        );
+
+        binding.layoutSearchBar.etSearch.setOnEditorActionListener((v, actionId, event) -> {
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                onSearch(binding.layoutSearchBar.etSearch.getText().toString());
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private void onSearch(@Nullable final String searchKey) {
+        for (OnSearchListener listener : onSearchListeners) {
+            listener.onSearch(searchKey);
+        }
+        closeKeyboard();
+    }
+
+    private void closeKeyboard(){
+        binding.layoutSearchBar.etSearch.clearFocus();
+        InputMethodManager inputManager =
+                (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+
+        if (inputManager != null) {
+            inputManager.hideSoftInputFromWindow(binding.layoutSearchBar.etSearch.getWindowToken(), 0);
         }
     }
 
@@ -74,8 +99,6 @@ public class SearchFragment extends BaseFragment<FragmentSearchBinding> {
 
         public SearchPagerAdapter(@NonNull FragmentManager fm) {
             super(fm);
-            fragments[0] = ProfileFragment.newInstance("");
-            fragments[1] = ProfileFragment.newInstance("");
         }
 
         @NonNull

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedFragment.java
@@ -1,0 +1,65 @@
+package com.boostcamp.dreampicker.presentation.search.feed;
+
+import android.os.Bundle;
+import android.view.View;
+
+import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.data.model.Feed;
+import com.boostcamp.dreampicker.data.source.remote.firebase.FeedFirebaseService;
+import com.boostcamp.dreampicker.data.source.repository.FeedRepository;
+import com.boostcamp.dreampicker.databinding.FragmentSearchFeedBinding;
+import com.boostcamp.dreampicker.presentation.BaseFragment;
+import com.boostcamp.dreampicker.presentation.profile.ProfileFeedAdapter;
+import com.boostcamp.dreampicker.presentation.search.OnSearchListener;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProviders;
+
+public class SearchFeedFragment extends BaseFragment<FragmentSearchFeedBinding> implements OnSearchListener {
+
+    public SearchFeedFragment() {
+    }
+
+    public static SearchFeedFragment newInstance() {
+        return new SearchFeedFragment();
+    }
+
+    @Override
+    protected int getLayoutId() {
+        return R.layout.fragment_search_feed;
+    }
+
+    @Override
+    public void onSearch(@Nullable String searchKey) {
+        // TODO. 리스트 초기화, searchKey 로 검색 재요청
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        initViewModel();
+        initRecyclerView();
+    }
+
+    private void initViewModel() {
+        final SearchFeedViewModel viewModel = ViewModelProviders.of(
+                this,
+                new SearchFeedViewModel.Factory(
+                        FeedRepository.getInstance(FeedFirebaseService.getInstance())
+                )
+        ).get(SearchFeedViewModel.class);
+        binding.setVm(viewModel);
+        binding.getVm().getError().observe(this, Throwable::printStackTrace);
+    }
+
+    private void initRecyclerView() {
+        ProfileFeedAdapter adapter = new ProfileFeedAdapter(this::startFeedDetailActivity);
+        binding.recyclerSearchFeed.setAdapter(adapter);
+    }
+
+    private void startFeedDetailActivity(Feed feed) {
+        // TODO. 유저 프로필 화면 띄우기
+    }
+
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedPagedDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedPagedDataSource.java
@@ -1,0 +1,109 @@
+package com.boostcamp.dreampicker.presentation.search.feed;
+
+import android.annotation.SuppressLint;
+
+import com.boostcamp.dreampicker.data.model.Feed;
+import com.boostcamp.dreampicker.data.source.repository.FeedRepository;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
+import androidx.paging.DataSource;
+import androidx.paging.PageKeyedDataSource;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+
+public class SearchFeedPagedDataSource extends PageKeyedDataSource<Integer, Feed> {
+
+    @NonNull
+    private CompositeDisposable disposable;
+    @NonNull
+    private FeedRepository repository;
+    @NonNull
+    private String userId;
+
+    private SearchFeedPagedDataSource(@NonNull FeedRepository repository,
+                                      @NonNull CompositeDisposable disposable,
+                                      @NonNull String userId) {
+        this.repository = repository;
+        this.disposable = disposable;
+        this.userId = userId;
+    }
+
+    /**
+     * 첫 페이지 로딩요청
+     */
+    @SuppressLint("CheckResult")
+    @Override
+    public void loadInitial(@NonNull LoadInitialParams<Integer> params,
+                            @NonNull LoadInitialCallback<Integer, Feed> callback) {
+
+        disposable.add(repository.addProfileFeedList(userId, 1, params.requestedLoadSize)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(response ->
+                                callback.onResult(response.getItemList(),
+                                        response.getDisplay(),
+                                        response.getStart() + response.getDisplay()),
+                        error -> {
+                        }
+                )
+        );
+    }
+
+    @SuppressLint("CheckResult")
+    @Override
+    public void loadBefore(@NonNull LoadParams<Integer> params,
+                           @NonNull LoadCallback<Integer, Feed> callback) {
+        // ignore
+    }
+
+    /**
+     * 첫 번째 페이지 제외 그 다음 페이지부터 로딩요청
+     * TODO. 마지막 페이지 limit 처리 필요함
+     */
+    @SuppressLint("CheckResult")
+    @Override
+    public void loadAfter(@NonNull LoadParams<Integer> params,
+                          @NonNull LoadCallback<Integer, Feed> callback) {
+
+        disposable.add(repository.addProfileFeedList(userId, params.key, params.requestedLoadSize)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(response ->
+                                callback.onResult(response.getItemList(),
+                                        params.key + response.getDisplay()),
+                        error -> {
+                        }
+                )
+        );
+    }
+
+
+    public static class Factory extends DataSource.Factory<Integer, Feed> {
+
+        @NonNull
+        private CompositeDisposable disposable;
+        @NonNull
+        private final FeedRepository repository;
+        @NonNull
+        private final String userId;
+
+        public Factory(@NonNull FeedRepository repository,
+                       @NonNull CompositeDisposable disposable,
+                       @NonNull String userId) {
+            this.repository = repository;
+            this.disposable = disposable;
+            this.userId = userId;
+        }
+
+        // TODO. liveData.postValue() 왜 필요한지 알아보기
+        private MutableLiveData<SearchFeedPagedDataSource> liveData =
+                new MutableLiveData<>();
+
+        @NonNull
+        @Override
+        public DataSource<Integer, Feed> create() {
+            SearchFeedPagedDataSource source = new SearchFeedPagedDataSource(repository, disposable, userId);
+            liveData.postValue(source);
+            return source;
+        }
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedViewModel.java
@@ -1,0 +1,76 @@
+package com.boostcamp.dreampicker.presentation.search.feed;
+
+import com.boostcamp.dreampicker.data.model.Feed;
+import com.boostcamp.dreampicker.data.source.repository.FeedRepository;
+import com.boostcamp.dreampicker.presentation.BaseViewModel;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.paging.LivePagedListBuilder;
+import androidx.paging.PagedList;
+
+/**
+ * TODO.
+ * 1. 에러처리
+ * 2. 로딩 중 표시
+ * 3. 새로고침(refresh layout)
+ */
+public class SearchFeedViewModel extends BaseViewModel {
+    private final int PAGE_SIZE = 20;
+
+    @NonNull
+    private FeedRepository repository;
+
+    @NonNull
+    public LiveData<PagedList<Feed>> feedPagedList;
+    @NonNull
+    private MutableLiveData<Throwable> error = new MutableLiveData<>();
+
+    private final PagedList.Config config = new PagedList.Config.Builder()
+            .setInitialLoadSizeHint(PAGE_SIZE)
+            .setPageSize(PAGE_SIZE)
+            .setPrefetchDistance(2) // 아래서 2번째 아이템이 보일 때 로딩시작
+            .setEnablePlaceholders(false) // 전체 사이즈 알고있는 경우(Countable List)에만 유효함
+            .build();
+
+    private SearchFeedViewModel(@NonNull FeedRepository repository) {
+        this.repository = repository;
+        loadSearchFeed("");
+    }
+
+    public void loadSearchFeed(@NonNull String searchKey) {
+        this.feedPagedList = new LivePagedListBuilder<>(
+                new SearchFeedPagedDataSource.Factory(repository, compositeDisposable, searchKey),
+                config
+        ).build();
+    }
+
+    @NonNull
+    public LiveData<Throwable> getError() {
+        return error;
+    }
+
+
+    static class Factory implements ViewModelProvider.Factory {
+
+        @NonNull
+        private final FeedRepository repository;
+
+        Factory(@NonNull FeedRepository repository) {
+            this.repository = repository;
+        }
+
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            if (modelClass.isAssignableFrom(SearchFeedViewModel.class)) {
+                //noinspection unchecked
+                return (T) new SearchFeedViewModel(repository);
+            }
+            throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass.getName());
+        }
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserAdapter.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserAdapter.java
@@ -1,0 +1,65 @@
+package com.boostcamp.dreampicker.presentation.search.user;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.data.model.User;
+import com.boostcamp.dreampicker.databinding.ItemSearchUserBinding;
+import com.boostcamp.dreampicker.presentation.BasePagedListAdapter;
+import com.boostcamp.dreampicker.presentation.listener.OnItemClickListener;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+import androidx.recyclerview.widget.DiffUtil;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class SearchUserAdapter extends BasePagedListAdapter<User, SearchUserAdapter.ViewHolder> {
+
+    public SearchUserAdapter(@Nullable OnItemClickListener<User> onItemClickListener) {
+        super(DIFF_CALLBACK, onItemClickListener);
+    }
+
+    @Override
+    protected void onBindView(ViewHolder holder, int position) {
+        final User user = getItem(position);
+        holder.bindTo(user);
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        return new ViewHolder(LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_search_user, parent, false));
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder {
+
+        ItemSearchUserBinding binding;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            binding = DataBindingUtil.bind(itemView);
+        }
+
+        void bindTo(User user) {
+            binding.setUser(user);
+        }
+    }
+
+    private static final DiffUtil.ItemCallback<User> DIFF_CALLBACK =
+            new DiffUtil.ItemCallback<User>() {
+                @Override
+                public boolean areItemsTheSame(@NonNull User oldItem, @NonNull User newItem) {
+                    return oldItem.getId().equals(newItem.getId());
+                }
+
+                @Override
+                public boolean areContentsTheSame(@NonNull User oldItem, @NonNull User newItem) {
+                    return oldItem.equals(newItem);
+                }
+            };
+
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserFragment.java
@@ -1,0 +1,64 @@
+package com.boostcamp.dreampicker.presentation.search.user;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import com.boostcamp.dreampicker.R;
+import com.boostcamp.dreampicker.data.model.User;
+import com.boostcamp.dreampicker.data.source.remote.firebase.UserFirebaseService;
+import com.boostcamp.dreampicker.data.source.repository.UserRepository;
+import com.boostcamp.dreampicker.databinding.FragmentSearchUserBinding;
+import com.boostcamp.dreampicker.presentation.BaseFragment;
+import com.boostcamp.dreampicker.presentation.search.OnSearchListener;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProviders;
+
+public class SearchUserFragment extends BaseFragment<FragmentSearchUserBinding> implements OnSearchListener {
+
+    public SearchUserFragment() { }
+
+    public static SearchUserFragment newInstance() {
+        return new SearchUserFragment();
+    }
+
+    @Override
+    protected int getLayoutId() {
+        return R.layout.fragment_search_user;
+    }
+
+    @Override
+    public void onSearch(@Nullable String searchKey) {
+        // TODO. 리스트 초기화, searchKey 로 검색 재요청
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        initViewModel();
+        initRecyclerView();
+    }
+
+    private void initViewModel() {
+        final SearchUserViewModel viewModel = ViewModelProviders.of(
+                this,
+                new SearchUserViewModel.Factory(
+                        UserRepository.getInstance(UserFirebaseService.getInstance())
+                )
+        ).get(SearchUserViewModel.class);
+        binding.setVm(viewModel);
+        binding.getVm().getError().observe(this, Throwable::printStackTrace);
+    }
+
+    private void initRecyclerView() {
+        SearchUserAdapter adapter = new SearchUserAdapter(this::startUserProfileActivity);
+        binding.recyclerSearchUser.setAdapter(adapter);
+    }
+
+    private void startUserProfileActivity(User user) {
+        // TODO. 유저 프로필 화면 띄우기
+    }
+
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserPagedDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserPagedDataSource.java
@@ -1,0 +1,95 @@
+package com.boostcamp.dreampicker.presentation.search.user;
+
+import com.boostcamp.dreampicker.data.model.User;
+import com.boostcamp.dreampicker.data.source.repository.UserRepository;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.MutableLiveData;
+import androidx.paging.DataSource;
+import androidx.paging.PageKeyedDataSource;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+
+public class SearchUserPagedDataSource extends PageKeyedDataSource<Integer, User> {
+
+    @NonNull
+    private UserRepository repository;
+    @NonNull
+    private CompositeDisposable disposable;
+    @NonNull
+    private String searchKey;
+
+    private SearchUserPagedDataSource(@NonNull UserRepository repository,
+                                      @NonNull CompositeDisposable disposable,
+                                      @NonNull String searchKey) {
+        this.repository = repository;
+        this.disposable = disposable;
+        this.searchKey = searchKey;
+    }
+
+    @Override
+    public void loadInitial(@NonNull LoadInitialParams<Integer> params,
+                            @NonNull LoadInitialCallback<Integer, User> callback) {
+
+        disposable.add(repository.addSearchUserList(searchKey, 1, params.requestedLoadSize)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(response -> callback.onResult(response.getItemList(),
+                        response.getDisplay(),
+                        response.getStart() + response.getDisplay()),
+                        error -> { }
+                )
+        );
+    }
+
+    @Override
+    public void loadBefore(@NonNull LoadParams<Integer> params,
+                           @NonNull LoadCallback<Integer, User> callback) {
+        // ignore
+    }
+
+    @Override
+    public void loadAfter(@NonNull LoadParams<Integer> params,
+                          @NonNull LoadCallback<Integer, User> callback) {
+
+        disposable.add(repository.addSearchUserList(searchKey, params.key, params.requestedLoadSize)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(response ->
+                                callback.onResult(response.getItemList(),
+                                        params.key + response.getDisplay()),
+                        error -> { }
+                )
+        );
+    }
+
+
+    static class Factory extends DataSource.Factory<Integer, User> {
+
+        @NonNull
+        private UserRepository repository;
+        @NonNull
+        private CompositeDisposable disposable;
+        @NonNull
+        private String searchKey;
+
+        public Factory(@NonNull UserRepository repository,
+                       @NonNull CompositeDisposable disposable,
+                       @NonNull String searchKey) {
+            this.repository = repository;
+            this.disposable = disposable;
+            this.searchKey = searchKey;
+        }
+
+        @NonNull
+        private MutableLiveData<SearchUserPagedDataSource> liveData =
+                new MutableLiveData<>();
+
+        @NonNull
+        @Override
+        public DataSource<Integer, User> create() {
+            SearchUserPagedDataSource source =
+                    new SearchUserPagedDataSource(repository, disposable, searchKey);
+            liveData.postValue(source);
+            return source;
+        }
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserViewModel.java
@@ -1,0 +1,68 @@
+package com.boostcamp.dreampicker.presentation.search.user;
+
+import com.boostcamp.dreampicker.data.model.User;
+import com.boostcamp.dreampicker.data.source.repository.UserRepository;
+import com.boostcamp.dreampicker.presentation.BaseViewModel;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.paging.LivePagedListBuilder;
+import androidx.paging.PagedList;
+
+public class SearchUserViewModel extends BaseViewModel {
+    private final int PAGE_SIZE = 20;
+
+    @NonNull
+    private UserRepository repository;
+
+    @NonNull
+    public LiveData<PagedList<User>> userPagedList;
+    @NonNull
+    private MutableLiveData<Throwable> error = new MutableLiveData<>();
+
+    private final PagedList.Config config = new PagedList.Config.Builder()
+            .setInitialLoadSizeHint(PAGE_SIZE)
+            .setPageSize(PAGE_SIZE)
+            .setPrefetchDistance(2) // 아래서 2번째 아이템이 보일 때 로딩시작
+            .setEnablePlaceholders(false) // 전체 사이즈 알고있는 경우(Countable List)에만 유효함
+            .build();
+
+    private SearchUserViewModel(@NonNull UserRepository repository) {
+        this.repository = repository;
+        loadSearchUser("");
+    }
+
+    public void loadSearchUser(@NonNull String searchKey) {
+        this.userPagedList = new LivePagedListBuilder<>(
+                new SearchUserPagedDataSource.Factory(repository, compositeDisposable, searchKey),
+                config).build();
+    }
+
+    @NonNull
+    public MutableLiveData<Throwable> getError() {
+        return error;
+    }
+
+    static class Factory implements ViewModelProvider.Factory {
+
+        @NonNull
+        private UserRepository repository;
+
+        Factory(@NonNull UserRepository repository) {
+            this.repository = repository;
+        }
+
+        @NonNull
+        @Override
+        public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+            if (modelClass.isAssignableFrom(SearchUserViewModel.class)) {
+                //noinspection unchecked
+                return (T) new SearchUserViewModel(repository);
+            }
+            throw new IllegalArgumentException("Unknown ViewModel class: " + modelClass.getName());
+        }
+    }
+}

--- a/app/src/main/java/com/boostcamp/dreampicker/utils/BindingUtil.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/utils/BindingUtil.java
@@ -11,6 +11,8 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.databinding.BindingAdapter;
+import androidx.paging.PagedList;
+import androidx.paging.PagedListAdapter;
 import androidx.recyclerview.widget.ListAdapter;
 import androidx.recyclerview.widget.RecyclerView;
 import me.gujun.android.taggroup.TagGroup;
@@ -24,6 +26,17 @@ public class BindingUtil {
         final ListAdapter<T, VH> adapter = (ListAdapter<T, VH>) recyclerView.getAdapter();
         if (adapter != null) {
             adapter.submitList(items == null ? null : new ArrayList<>(items));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @BindingAdapter({"pagedItems"})
+    public static <T, VH extends RecyclerView.ViewHolder> void setPagedItems(
+            @NonNull final RecyclerView recyclerView,
+            @Nullable final PagedList<T> items) {
+        final PagedListAdapter<T, VH> adapter = (PagedListAdapter<T, VH>) recyclerView.getAdapter();
+        if (adapter != null) {
+            adapter.submitList(items);
         }
     }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/utils/FirebaseManager.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/utils/FirebaseManager.java
@@ -1,0 +1,24 @@
+package com.boostcamp.dreampicker.utils;
+
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
+
+import androidx.annotation.Nullable;
+
+public class FirebaseManager {
+
+    /**
+     * ID 만 필요한 곳에서 사용됨 */
+    @Nullable
+    public static String getCurrentUserId(){
+        final FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        return user == null ? null : user.getUid();
+    }
+
+    /**
+     * 내 프로필 화면에서 사용됨 */
+    @Nullable
+    public static FirebaseUser getCurrentUser(){
+        return FirebaseAuth.getInstance().getCurrentUser();
+    }
+}

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -128,11 +128,12 @@
             android:id="@+id/recycler_profile_feed"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tab_profile" />
+            app:layout_constraintTop_toBottomOf="@id/tab_profile"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:pagedItems="@{feedVm.feedPagedList}"/>
 
     </androidx.constraintlayout.motion.widget.MotionLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -18,6 +18,7 @@
                 android:orientation="vertical">
 
                 <include
+                    android:id="@+id/layout_search_bar"
                     layout="@layout/layout_search_bar"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>

--- a/app/src/main/res/layout/fragment_search_feed.xml
+++ b/app/src/main/res/layout/fragment_search_feed.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.boostcamp.dreampicker.presentation.search.feed.SearchFeedViewModel" />
+    </data>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_search_feed"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:pagedItems="@{vm.feedPagedList}"/>
+
+</layout>

--- a/app/src/main/res/layout/fragment_search_user.xml
+++ b/app/src/main/res/layout/fragment_search_user.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.boostcamp.dreampicker.presentation.search.user.SearchUserViewModel"/>
+    </data>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_search_user"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:pagedItems="@{vm.userPagedList}"/>
+</layout>

--- a/app/src/main/res/layout/item_profile_feed.xml
+++ b/app/src/main/res/layout/item_profile_feed.xml
@@ -56,8 +56,8 @@
                     android:gravity="center_vertical">
 
                     <ImageView
-                        android:layout_width="@dimen/profile_image_size_median"
-                        android:layout_height="@dimen/profile_image_size_median"
+                        android:layout_width="@dimen/profile_image_size_small"
+                        android:layout_height="@dimen/profile_image_size_small"
                         android:layout_margin="@dimen/space_median"
                         app:circleImage="@{item.user.profileImageUrl}"/>
 

--- a/app/src/main/res/layout/item_search_user.xml
+++ b/app/src/main/res/layout/item_search_user.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="user"
+            type="com.boostcamp.dreampicker.data.model.User"/>
+    </data>
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="5dp"
+        app:cardUseCompatPadding="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <ImageView
+                style="@style/ImageView"
+                android:layout_margin="@dimen/space_median"
+                android:layout_width="@dimen/profile_image_size_median"
+                android:layout_height="@dimen/profile_image_size_median"
+                app:circleImage="@{user.profileImageUrl}"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{user.name}"
+                android:textSize="@dimen/text_large"
+                android:textColor="@color/colorBlack"/>
+        </LinearLayout>
+    </androidx.cardview.widget.CardView>
+</layout>

--- a/app/src/main/res/layout/layout_search_bar.xml
+++ b/app/src/main/res/layout/layout_search_bar.xml
@@ -7,13 +7,16 @@
         android:orientation="horizontal">
 
         <EditText
+            android:id="@+id/et_search"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="match_parent"
             android:hint="@string/search_text_hint"
+            android:imeOptions="actionSearch"
             style="@style/EditText.Search"/>
 
         <ImageButton
+            android:id="@+id/btn_search"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:padding="@dimen/space_small"


### PR DESCRIPTION
﻿### 개요
- 검색 화면 뷰모델 적용
- 검색 화면 페이징 처리
- 유저 검색 결과, 피드 검색 결과

프로필의 피드 목록과 동일하게 작성했습니다. #107 

파이어베이스에서 유저정보 가져오는 FirebaseManager 추가했습니다. (대근님 리뷰 부탁드립니다)

PagedAdapter, PagedDataSource가 겹치는 내용이 너무 많아 계속 똑같이 찍어내고 있는데
추후 리팩토링 필요할 것 같습니다.
<hr>

- resolved : #48 