### PR TITLE
pagedDataSource disposable 제거

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,6 @@ dependencies {
 
     // Paging
     implementation "androidx.paging:paging-runtime:2.1.0"
-    implementation "androidx.paging:paging-rxjava2:2.1.0"
 
     // RxAndroid
     implementation "io.reactivex.rxjava2:rxjava:2.2.6"

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/BaseViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/BaseViewModel.java
@@ -5,7 +5,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 
 public abstract class BaseViewModel extends ViewModel {
-    protected CompositeDisposable compositeDisposable;
+    private CompositeDisposable compositeDisposable;
 
     protected BaseViewModel() {
         compositeDisposable = new CompositeDisposable();

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFeedViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/profile/ProfileFeedViewModel.java
@@ -37,7 +37,7 @@ public class ProfileFeedViewModel extends BaseViewModel {
                 .build();
 
         this.feedPagedList = new LivePagedListBuilder<>(
-                new ProfileFeedPagedDataSource.Factory(repository, compositeDisposable, userId), config)
+                new ProfileFeedPagedDataSource.Factory(repository, userId), config)
                 .build();
     }
 

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/feed/SearchFeedViewModel.java
@@ -43,7 +43,7 @@ public class SearchFeedViewModel extends BaseViewModel {
 
     public void loadSearchFeed(@NonNull String searchKey) {
         this.feedPagedList = new LivePagedListBuilder<>(
-                new SearchFeedPagedDataSource.Factory(repository, compositeDisposable, searchKey),
+                new SearchFeedPagedDataSource.Factory(repository, searchKey),
                 config
         ).build();
     }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/search/user/SearchUserViewModel.java
@@ -37,7 +37,7 @@ public class SearchUserViewModel extends BaseViewModel {
 
     public void loadSearchUser(@NonNull String searchKey) {
         this.userPagedList = new LivePagedListBuilder<>(
-                new SearchUserPagedDataSource.Factory(repository, compositeDisposable, searchKey),
+                new SearchUserPagedDataSource.Factory(repository, searchKey),
                 config).build();
     }
 


### PR DESCRIPTION
﻿### 개요
생성자에서 주입받던 compositeDisposable 을 제거하고 subscribe 대신 blockingGet으로 대체

BaseViewModel의 DompositeDisposable 접근제어자 private 으로 다시변경했습니다.
Paging-rx 사용하지 않아서 제거했습니다. 
<hr>

### 체크리스트
- [x] profileFeedPagedDataSource 수정
- [x] SearchFeedPagedDataSource 수정
- [x] SearchUserPagedDataSource 수정

<hr>

- resolved : #123 