### PR TITLE
메인피드 Url로 변경 및 데이터 최적화

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/data/model/Feed.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/model/Feed.java
@@ -4,19 +4,18 @@ import java.util.Map;
 import java.util.Objects;
 
 public class Feed {
-    private String id;
-    private Map<String, Image> imageMap;
-    private User user;
-    private String content;
-    private String date;
+    private String id; // 피드 아이디
+    private Map<String, Image> imageMap; // 피드 이미지 리스트
+    private User user; // 업로더
+    private String content; // 본문
+    private String date; // 업로드 일자
 
-    // TODO : 마감 조건 확인 이후 작업
+    private int leftCount; // L 투표 수
+    private int rightCount; // R 투표 수
+    private int voteFlag; // 투표 합
+
+    // Todo : 아직 미정
     private boolean isEnded;
-    // TODO : Firestore 연동 이후 작업
-    private int leftCount;
-    private int rightCount;
-
-    private int voteFlag;
 
     public Feed() { }
 
@@ -47,7 +46,6 @@ public class Feed {
         this.isEnded = isEnded;
         this.leftCount = 3;
         this.rightCount = 4;
-        this.voteFlag = 0;
     }
 
     public String getId() {

--- a/app/src/main/java/com/boostcamp/dreampicker/data/model/Image.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/model/Image.java
@@ -6,26 +6,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Image {
-    private String id;
-
-    // Todo 이후 변경 예정
-    private Uri uri;
-
-    private int image;
-    // TODO : 이후 URL로 변경 예정
-    private String imageUrl;
-    // TODO : 이후 TagGroup 적용
-    private String tag;
-    private List<String> tagList;
+    private String id; // 이미지 아이디
+    private Uri uri; // 업로드 할때 들어가는 uri
+    private int image; // 임시 데이터
+    private String imageUrl; // 파이어베이스로부터 받아오는 경로
+    private List<String> tagList; // 태그 리스트
 
     public Image() {
         this.tagList = new ArrayList<>();
     }
 
-    public Image(String id, int image, String tag) {
+    public Image(String id, String imageUrl, List<String> tagList) {
         this.id = id;
-        this.image = image;
-        this.tag = tag;
+        this.imageUrl = imageUrl;
+        this.tagList = tagList;
     }
 
     public Image(String id, Uri uri, List<String> tagList) {
@@ -34,7 +28,6 @@ public class Image {
         this.tagList = tagList;
     }
 
-    // Test
     public Image(String id, int image, List<String> tagList) {
         this.id = id;
         this.image = image;
@@ -71,14 +64,6 @@ public class Image {
 
     public void setImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
-    }
-
-    public String getTag() {
-        return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
     }
 
     public List<String> getTagList() {

--- a/app/src/main/java/com/boostcamp/dreampicker/data/model/User.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/model/User.java
@@ -1,14 +1,13 @@
 package com.boostcamp.dreampicker.data.model;
 
 public class User {
-    private String id;
-    private String name;
-    private String profileImageUrl;
+    private String id; // 유저 아이디
+    private String name; // 유저 이름
+    private String profileImageUrl; // 유저 프로필 사진 url
     // TODO : 이후 url로 변경
-    private int profileImageResource;
+    private int profileImageResource; // 유저 임시 사진?
 
-    public User() {
-    }
+    public User() { }
 
     public User(String id, String name, int profileImageResource) {
         this.id = id;

--- a/app/src/main/java/com/boostcamp/dreampicker/data/model/UserDetail.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/model/UserDetail.java
@@ -3,21 +3,20 @@ package com.boostcamp.dreampicker.data.model;
 import java.util.List;
 
 public class UserDetail {
-    private String id;
-    private String name;
-    private String email;
-    private String profileImageUrl;
-    private int feedCount;
-    private int followerCount;
-    private int followingCount;
-    private boolean isFollow;
+    private String id; // 유저 아이디
+    private String name; // 유저 이름
+    private String email; // 유저 이메일
+    private String profileImageUrl; // 유저 프로필 url
+    private int feedCount; // 올린 피드 수
+    private int followerCount; // 팔로워 수
+    private int followingCount; // 팔로잉 수
+    private boolean isFollow; // 내가 이 사람을 팔로우 했는지 여부
 
-    private List<User> followerList;
-    private List<User> followingList;
-    private List<Feed> feedList;
+    private List<User> followerList; // 해당 유저의 팔로워 리스트
+    private List<User> followingList; // 해당 유저의 팔로잉 리스트
+    private List<Feed> feedList; // 해당 유저의 피드 리스트
 
-    public UserDetail() {
-    }
+    public UserDetail() { }
 
     public UserDetail(String id,
                       String name,

--- a/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/FeedMockDataSource.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/data/source/local/test/FeedMockDataSource.java
@@ -55,11 +55,17 @@ public class FeedMockDataSource implements FeedDataSource {
     private List<Feed> createMockFeedData() {
         final List<Feed> feedList = new ArrayList<>();
 
-        Image image1 = new Image("image-0-up", R.drawable.image1, Arrays.asList("1번", "2번", "3번"));
-        Image image2 = new Image("image-0-down", R.drawable.image2, Arrays.asList("1213112312", "2", "3", "4", "5", "6", "7"));
+        Image image1 = new Image("image-0-up",
+                "http://monthly.chosun.com/up_fd/Mdaily/2017-09/bimg_thumb/2017042000056_0.jpg",
+                Arrays.asList("1번", "2번", "3번"));
+        Image image2 = new Image("image-0-down",
+                "https://post-phinf.pstatic.net/MjAxNzA2MjhfODQg/MDAxNDk4NjU2MzgyNzcx.TVy7np7EVlKjuntLKN_qdwrGB8lGBdfMwkX6p3WV6rQg.6oHbF6lWH0iINgljB7CF3jSeYX342hsdl8fekB8yawsg.PNG/9.PNG?type=w1200",
+                Arrays.asList("1213112312", "2"));
+
         Map<String, Image> imageMap = new HashMap<>();
         imageMap.put("left", image1);
         imageMap.put("right", image2);
+
         User user1 = new User("user-0", "박신혜", R.drawable.profile);
         Feed feed1 = new Feed(
                 IdCreator.createFeedId(),
@@ -70,8 +76,13 @@ public class FeedMockDataSource implements FeedDataSource {
                 false
         );
 
-        Image image3 = new Image("image-1-up", R.drawable.jajang, Arrays.asList("짬뽕", "굿"));
-        Image image4 = new Image("image-1-down", R.drawable.jambong, Arrays.asList("이것도짬뽕ㅎㅎ", "ㅋㅋㅋ"));
+        Image image3 = new Image("image-1-up",
+                "https://t1.daumcdn.net/friends/prod/category/M201_theme_flying11.png",
+                Arrays.asList("짬뽕", "굿"));
+        Image image4 = new Image("image-1-down",
+                "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQkH0BPwI8ZSms_dTXMMrc9lU8OaO6oo729MzRe6HmjH7nUFDTn",
+                Arrays.asList("이것도짬뽕ㅎㅎ", "ㅋㅋㅋ"));
+
         User user2 = new User("user-1", "공유", R.drawable.profile2);
         Map<String, Image> imageMap2 = new HashMap<>();
         imageMap2.put("left", image3);
@@ -153,8 +164,8 @@ public class FeedMockDataSource implements FeedDataSource {
                                                              int display) {
         List<Feed> feedList = new ArrayList<>();
         for (int i = 0; i < display; i++) {
-            Image image1 = new Image("image-0-up", R.drawable.image1, "카페");
-            Image image2 = new Image("image-0-down", R.drawable.image2, "술집");
+            Image image1 = new Image("image-0-up", R.drawable.image1, Arrays.asList("술집", "카페"));
+            Image image2 = new Image("image-0-down", R.drawable.image2, Arrays.asList("집구석", "방구석"));
             Map<String, Image> imageMap = new HashMap<>();
             imageMap.put("left", image1);
             imageMap.put("right", image2);

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedFragment.java
@@ -64,9 +64,4 @@ public class FeedFragment extends BaseFragment<FragmentFeedBinding> {
         return R.layout.fragment_feed;
     }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-        binding.getViewModel().loadFeedList();
-    }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewHolder.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewHolder.java
@@ -26,6 +26,9 @@ class FeedViewHolder extends RecyclerView.ViewHolder {
 
     void bindTo(@NonNull Feed feed) {
         binding.setFeed(feed);
+        binding.ivFeedImageLeft.setTag(R.id.iv_feed_image_left, feed.getId());
+        binding.ivFeedImageRight.setTag(R.id.iv_feed_image_right, feed.getId());
+        binding.sbSelector.setTag(R.id.sb_selector, feed.getId());
     }
 
     public ItemFeedBinding getBinding() {

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewModel.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewModel.java
@@ -17,6 +17,7 @@ public class FeedViewModel extends BaseViewModel {
     @NonNull
     private final FeedRepository repository;
 
+    @NonNull
     private MutableLiveData<List<Feed>> feedList = new MutableLiveData<>();
 
     @NonNull
@@ -24,6 +25,7 @@ public class FeedViewModel extends BaseViewModel {
 
     FeedViewModel(@NonNull FeedRepository repository) {
         this.repository = repository;
+        loadFeedList();
     }
 
     void vote(@NonNull final VoteResult result) {
@@ -41,16 +43,16 @@ public class FeedViewModel extends BaseViewModel {
         }
     }
 
-    @NonNull
-    public LiveData<List<Feed>> getFeedList() {
-        return feedList;
-    }
-
     void loadFeedList() {
         addDisposable(repository.addMainFeedList(1, 10)
                 .map(PagedListResponse::getItemList)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(list -> feedList.postValue(list), error::setValue));
+    }
+
+    @NonNull
+    public LiveData<List<Feed>> getFeedList() {
+        return feedList;
     }
 
     @NonNull

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/listener/VoteDragListener.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/listener/VoteDragListener.java
@@ -3,6 +3,7 @@ package com.boostcamp.dreampicker.presentation.listener;
 import android.view.DragEvent;
 import android.view.View;
 
+import com.boostcamp.dreampicker.R;
 import com.sackcentury.shinebuttonlib.ShineButton;
 
 import androidx.annotation.NonNull;
@@ -20,8 +21,15 @@ public class VoteDragListener implements View.OnDragListener {
 
     public boolean onDrag(View v, DragEvent event) {
         final ShineButton button = (ShineButton) event.getLocalState();
-        final String buttonTag = button.getTag().toString();
-        final String containerTag = v.getTag().toString();
+        final String buttonTag = button.getTag(R.id.sb_selector).toString();
+
+        String containerTag = "";
+
+        if(v.getTag(R.id.iv_feed_image_left) != null) {
+            containerTag = v.getTag(R.id.iv_feed_image_left).toString();
+        } else if(v.getTag(R.id.iv_feed_image_right) != null) {
+            containerTag = v.getTag(R.id.iv_feed_image_right).toString();
+        }
 
         // 이벤트 시작
         switch (event.getAction()) {

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/listener/VoteIconTouchListener.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/listener/VoteIconTouchListener.java
@@ -6,6 +6,8 @@ import android.content.ClipDescription;
 import android.view.MotionEvent;
 import android.view.View;
 
+import com.boostcamp.dreampicker.R;
+
 @SuppressLint("ClickableViewAccessibility")
 public class VoteIconTouchListener implements View.OnTouchListener {
     @Override
@@ -14,7 +16,7 @@ public class VoteIconTouchListener implements View.OnTouchListener {
             // 태그 생성
             final ClipData.Item item = new ClipData.Item("");
             final String[] mimeTypes = {ClipDescription.MIMETYPE_TEXT_PLAIN};
-            final ClipData data = new ClipData(v.getTag().toString(), mimeTypes, item);
+            final ClipData data = new ClipData(v.getTag(R.id.sb_selector).toString(), mimeTypes, item);
 
             v.startDrag(data, // data to be dragged
                     new View.DragShadowBuilder(v), // drag shadow

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadActivity.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/upload/UploadActivity.java
@@ -9,9 +9,7 @@ import android.widget.Toast;
 
 import com.boostcamp.dreampicker.R;
 import com.boostcamp.dreampicker.data.source.remote.firebase.FeedFirebaseService;
-import com.boostcamp.dreampicker.data.source.remote.firebase.UserFirebaseService;
 import com.boostcamp.dreampicker.data.source.repository.FeedRepository;
-import com.boostcamp.dreampicker.data.source.repository.UserRepository;
 import com.boostcamp.dreampicker.databinding.ActivityUploadBinding;
 import com.boostcamp.dreampicker.presentation.BaseActivity;
 import com.boostcamp.dreampicker.utils.Constant;

--- a/app/src/main/res/layout/item_feed.xml
+++ b/app/src/main/res/layout/item_feed.xml
@@ -104,7 +104,6 @@
                     android:background="@drawable/ic_vote_bg"
                     android:clickable="false"
                     android:elevation="5dp"
-                    android:tag="@{feed.id}"
                     app:allow_random_color="true"
                     app:btn_color="@color/colorWhite"
                     app:big_shine_color="#66FFFF"
@@ -135,9 +134,8 @@
                     android:layout_width="0dp"
                     android:layout_height="@dimen/feed_photo_image_height"
                     android:scaleType="fitXY"
-                    android:tag="@{feed.id}"
                     android:layout_marginTop="@dimen/space_x_small"
-                    app:imageResource='@{feed.imageMap["left"].image}'
+                    app:image='@{feed.imageMap["left"].imageUrl}'
                     app:layout_constraintBottom_toTopOf="@id/vote_result"
                     app:layout_constraintEnd_toStartOf="@+id/guideline_feed_image_ho"
                     app:layout_constraintStart_toStartOf="parent"
@@ -159,9 +157,8 @@
                     android:layout_width="0dp"
                     android:layout_height="@dimen/feed_photo_image_height"
                     android:scaleType="fitXY"
-                    android:tag="@{feed.id}"
                     android:layout_marginTop="@dimen/space_x_small"
-                    app:imageResource='@{feed.imageMap["right"].image}'
+                    app:image='@{feed.imageMap["right"].imageUrl}'
                     app:layout_constraintBottom_toTopOf="@id/vote_result"
                     app:layout_constraintStart_toEndOf="@+id/guideline_feed_image_ho"
                     app:layout_constraintTop_toBottomOf="@id/tv_feed_content"


### PR DESCRIPTION
﻿### 개요
- 메인 피드 이미지 가져오는 방법을 `Resource` -> `Url`로 변경

<hr>

### 상세 내용
- 이미지에 들어가는 불필요한 생성자를 제거하였습니다.
- 데이터에 주석을 추가하였습니다.
- 테스트용 `MockDataSource`에 위 내용을 반영하였습니다.

<hr>

- resolved : #132 