### PR TITLE
[Issue-221] 태그리스트 미반영 버그 수정

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/extension/databinding/BindingUtil.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/extension/databinding/BindingUtil.java
@@ -1,12 +1,14 @@
 package com.boostcamp.dreampicker.extension.databinding;
 
 import android.annotation.SuppressLint;
+import android.view.View;
 import android.widget.TextView;
 
 import com.akexorcist.roundcornerprogressbar.RoundCornerProgressBar;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -46,6 +48,9 @@ public class BindingUtil {
     public static void setTagItems(@NonNull final TagGroup tagGroup, @Nullable final List<String> tagList) {
         if(tagList != null) {
             tagGroup.setTags(tagList);
+            tagGroup.setVisibility(View.VISIBLE);
+        } else {
+            tagGroup.setVisibility(View.GONE);
         }
     }
 


### PR DESCRIPTION
### 개요
- 메인 피드에서 태그 리스트가 재사용되는 문제가 있어 이를 해결하였습니다.

***

- resolved : #221 