### PR TITLE
[Issue-226] 상세보기 -> 메인 피드 onActivityResult 구현

### DIFF
--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/detail/FeedDetailActivity.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/detail/FeedDetailActivity.java
@@ -121,9 +121,10 @@ public class FeedDetailActivity extends BaseActivity<ActivityFeedDetailBinding> 
         binding.getVm().loadFeedDetail(feedId);
     }
 
-    @Override
-    protected int getLayoutId() {
-        return R.layout.activity_feed_detail;
+    private void closeActivity() {
+        final Intent intent = new Intent();
+        setResult(RESULT_OK, intent);
+        finish();
     }
 
     public static Intent getLaunchIntent(@NonNull Context context,
@@ -139,10 +140,20 @@ public class FeedDetailActivity extends BaseActivity<ActivityFeedDetailBinding> 
     }
 
     @Override
+    protected int getLayoutId() {
+        return R.layout.activity_feed_detail;
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            finish();
+            closeActivity();
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onBackPressed() {
+        closeActivity();
     }
 }

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedAdapter.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedAdapter.java
@@ -22,7 +22,7 @@ public class FeedAdapter extends ListAdapter<Feed, FeedViewHolder> {
     }
 
     interface OnProfileClickListener {
-        void onProfileClick(User writer);
+        void onProfileClick(@NonNull String writer);
     }
 
     interface OnVoteListener {
@@ -69,6 +69,7 @@ public class FeedAdapter extends ListAdapter<Feed, FeedViewHolder> {
                 onItemClickListener.onItemClick(feed.getId(),
                         feed.getItemA().getImageUrl(),
                         feed.getItemB().getImageUrl()));
+
         if (feed.getSelectionId() != null) {
             if (!holder.getBinding().cbFeedVoteCount.isChecked()) {
                 holder.getBinding().cbFeedVoteCount.performClick();
@@ -98,7 +99,7 @@ public class FeedAdapter extends ListAdapter<Feed, FeedViewHolder> {
                 }));
 
         holder.getBinding().ivWriterImg.setOnClickListener(v ->
-                onProfileClickListener.onProfileClick(feed.getWriter()));
+                onProfileClickListener.onProfileClick(feed.getWriter().getId()));
     }
 
     private static final DiffUtil.ItemCallback<Feed> DIFF_CALLBACK =

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedFragment.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedFragment.java
@@ -1,14 +1,12 @@
 package com.boostcamp.dreampicker.presentation.feed.main;
 
-import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
 import com.boostcamp.dreampicker.R;
-import com.boostcamp.dreampicker.di.Injection;
 import com.boostcamp.dreampicker.databinding.FragmentFeedBinding;
+import com.boostcamp.dreampicker.di.Injection;
 import com.boostcamp.dreampicker.presentation.BaseFragment;
 import com.boostcamp.dreampicker.presentation.feed.detail.FeedDetailActivity;
 import com.boostcamp.dreampicker.presentation.profile.ProfileActivity;
@@ -24,8 +22,6 @@ import io.reactivex.disposables.CompositeDisposable;
 import static android.app.Activity.RESULT_OK;
 
 public class FeedFragment extends BaseFragment<FragmentFeedBinding> {
-    private static final String TEXT_LAST_PAGE = "마지막 페이지입니다.";
-    private static final String ERROR_MESSAGE = "에러가 발생했습니다.";
 
     private boolean isLastPage = false;
 
@@ -68,7 +64,7 @@ public class FeedFragment extends BaseFragment<FragmentFeedBinding> {
                 super.onScrollStateChanged(recyclerView, newState);
                 if (!binding.rvFeed.canScrollVertically(RecyclerView.FOCUS_DOWN)) {
                     if (isLastPage) {
-                        showToast(TEXT_LAST_PAGE);
+                        showToast(getString(R.string.feed_last_page));
                     } else {
                         binding.getVm().loadFeedList();
                     }
@@ -98,7 +94,7 @@ public class FeedFragment extends BaseFragment<FragmentFeedBinding> {
         // Todo : Swipe 막기 처리 필요
         binding.getVm().getIsLastPage().observe(this, isLastPage -> this.isLastPage = isLastPage);
 
-        binding.getVm().getError().observe(this, e -> showToast(ERROR_MESSAGE));
+        binding.getVm().getError().observe(this, e -> showToast(getString(R.string.feed_error_message)));
     }
 
     private void showToast(String msg) {

--- a/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewHolder.java
+++ b/app/src/main/java/com/boostcamp/dreampicker/presentation/feed/main/FeedViewHolder.java
@@ -36,7 +36,6 @@ class FeedViewHolder extends RecyclerView.ViewHolder {
                             @NonNull final String itemBId,
                             @Nullable final String selectionId) {
         final Context context = binding.getRoot().getContext();
-
         final int size = context.getResources().getDimensionPixelSize(R.dimen.vote_icon_size);
 
         final ShineButton button = binding.sbSelector;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,10 +4,13 @@
 
     <!-- 메인화면에서 사용 -->
     <string name="main_navigation_home">홈</string>
-    <string name="main_navigation_search">검색</string>
     <string name="main_navigation_upload">업로드</string>
-    <string name="main_navigation_notification">결과</string>
+    <string name="main_navigation_notification">내투표</string>
     <string name="main_navigation_profile">프로필</string>
+
+    <!-- 메인 피드 -->
+    <string name="feed_last_page">마지막 페이지입니다.</string>
+    <string name="feed_error_message">에러가 발생했습니다.</string>
 
     <!-- 프로필 화면에서 사용 -->
     <string name="profile_feed_count">업로드</string>
@@ -16,12 +19,8 @@
     <string name="profile_request_end">마감하기</string>
     <string name="profile_request_restart">재진행하기</string>
 
-    <!-- 검색 화면에서 사용 -->
-    <string name="search_text_hint">검색어를 입력하세요.</string>
-
     <!-- 투표 결과에서 사용 -->
     <string name="vote_result_title">투표</string>
-
 
     <!-- 업로드 화면에서 사용 -->
     <string name="upload_et_content_hint">무슨 고민이 있나요?</string>


### PR DESCRIPTION
﻿### 개요
- 상세보기에서 투표 진행 후 메인 피드로 돌아오면 Fragment가 감지합니다.
- 이후 ViewModel에 해당 Feed의 수정 내역을 변경 요청합니다.

<hr>

- resolved : #226 